### PR TITLE
Fix wrong Prognosis target check

### DIFF
--- a/BasicRotations/Healer/SGE_Default.cs
+++ b/BasicRotations/Healer/SGE_Default.cs
@@ -201,7 +201,7 @@ public sealed class SGE_Default : SageRotation
     {
         if (EukrasianPrognosisPvE.CanUse(out act))
         {
-            if (EukrasianDiagnosisPvE.Target.Target?.HasStatus(false,
+            if (EukrasianPrognosisPvE.Target.Target?.HasStatus(false,
                 StatusID.EukrasianDiagnosis,
                 StatusID.EukrasianPrognosis,
                 StatusID.Galvanize


### PR DESCRIPTION
While playing SGE, sometimes RSR just stops doing anything because of a crash:
![grafik](https://github.com/FFXIV-CombatReborn/RebornRotations/assets/38253929/7239aefe-b7ad-4950-b1c7-7c60a50aaa6e)
After looking at the source, I found that we are checking the target of `EukrasianDiagnosisPvE` inside of `EukrasianPrognosisPvE`, which is the wrong spell. This leads to the "corrupted memory read" from the error message, because the target of `Diagnosis` might be an invalid reference now that we are casting `Prognosis`.
I guess that was a copy-paste mistake from the method just below, where `EukrasianDiagnosisPvE` is defined with similar code structure.