### PR TITLE
Fix PCT getting stuck above level 90

### DIFF
--- a/BasicRotations/Magical/PCT_Default.cs
+++ b/BasicRotations/Magical/PCT_Default.cs
@@ -142,6 +142,7 @@ public sealed class PCT_Default : PictomancerRotation
         }
         else
         {
+            if (Player.HasStatus(true, StatusID.MonochromeTones) && CometInBlackPvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true)) return true;
             if (HolyInWhitePvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true)) return true;
             //AOE
             if (WaterIiInBluePvE.CanUse(out act)) return true;


### PR DESCRIPTION
The PCT rotation gets stuck after level 90 because of the new spell Comet in Black. It has to be casted before using Holy in White, or else RSR gets stuck trying to cast Holy in White.