### PR TITLE
PLD80-89 fix

### DIFF
--- a/BasicRotations/Tank/PLD_Default.cs
+++ b/BasicRotations/Tank/PLD_Default.cs
@@ -122,10 +122,17 @@ public class PLD_Default : PaladinRotation
 
         if (Player.HasStatus(true, StatusID.Requiescat))
         {
-            if (BladeOfFaithPvE.EnoughLevel && BladeOfValorPvE.CanUse(out act, skipAoeCheck: true)) return true;
-            if (BladeOfFaithPvE.EnoughLevel && BladeOfTruthPvE.CanUse(out act, skipAoeCheck: true)) return true;
-            if (BladeOfFaithPvE.EnoughLevel && BladeOfFaithPvE.CanUse(out act, skipAoeCheck: true)) return true;
-            if (ConfiPvE.CanUse(out act, skipAoeCheck: true)) return true;
+            if ((Player.Level >= 90) && (Player.StatusStack(true, StatusID.Requiescat) < 4))
+            {
+                //if (BladeOfValorPvE.CanUse(out act, skipAoeCheck: true)) return true;
+                //if (BladeOfTruthPvE.CanUse(out act, skipAoeCheck: true)) return true;
+                //if (BladeOfFaithPvE.CanUse(out act, skipAoeCheck: true)) return true;
+                if (ConfiPvE.CanUse(out act, skipAoeCheck: true)) return true;
+            }
+            if ((Player.Level >= 80) && (Player.StatusStack(true, StatusID.Requiescat) > 3))
+            {
+                if (ConfiPvE.CanUse(out act, skipAoeCheck: true)) return true;
+            }
             if (HolyCirclePvE.CanUse(out act)) return true;
             if (HolySpiritPvE.CanUse(out act)) return true;
         }


### PR DESCRIPTION
noticed in MtGulg that it would keep spamming confiteor under requiescat after it was used once

so i added a stack check for requiescat so that it would only call it when theres 4 stacks of requiescat hence stopping the spam and correctly using holy circle / spirit

however after that fix i noticed that once again for lvl90+ it wasn't using the blade combo, after some checks i've came to understand it doesnt use the blade skills but was only spamming confiteor, so i added another stack check specifically for lvl90+

fixes https://github.com/FFXIV-CombatReborn/RebornRotations/issues/53
fixes https://github.com/FFXIV-CombatReborn/RebornRotations/issues/49