### PR TITLE
Optimized warrior rotation. Perfection.

### DIFF
--- a/BasicRotations/Tank/WAR_Default.cs
+++ b/BasicRotations/Tank/WAR_Default.cs
@@ -56,7 +56,7 @@ public sealed class WAR_Default : WarriorRotation
         if (UseBurstMedicine(out act)) return true;
 
         if (Player.HasStatus(false, StatusID.SurgingTempest)
-            && !Player.WillStatusEndGCD(6, 0, true, StatusID.SurgingTempest)
+            && !Player.WillStatusEndGCD(2, 0, true, StatusID.SurgingTempest) // Less delaying of Inner Release which resulted in unsynced burst windows outside of raid buffs (IR grants +10 secs to ST) The opener is 6 GCDS= 15s on 2.5gcd
             || !MythrilTempestPvE.EnoughLevel)
         {
             if (BerserkPvE.CanUse(out act)) return true;
@@ -154,8 +154,8 @@ public sealed class WAR_Default : WarriorRotation
 
         if (!Player.WillStatusEndGCD(3, 0, true, StatusID.SurgingTempest))
         {
-            // New check for Primal Ruination
-            if (Player.HasStatus(false, StatusID.PrimalRuinationReady)) // Squeezed ruination into opener for raid buffs = big dps increase
+            
+            if (Player.HasStatus(false, StatusID.PrimalRuinationReady)) // Removed my initial Status check which delayed Ruination by roughly 15 seconds bc the opener on release was still semi-optimal. Ruination in opener is a big dps increase due to raid buffs
             {
                 if (PrimalRuinationPvE.CanUse(out act, skipAoeCheck: true)) return true;
             }

--- a/BasicRotations/Tank/WAR_Default.cs
+++ b/BasicRotations/Tank/WAR_Default.cs
@@ -2,7 +2,7 @@ using RotationSolver.Basic.Data;
 
 namespace DefaultRotations.Tank;
 
-[Rotation("Sascha", CombatType.PvE, GameVersion = "7.00", Description = "Additional Contributions from Sascha")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.00", Description = "Additional Contributions from Sascha")]
 [SourceCode(Path = "main/DefaultRotations/Tank/WAR_Default.cs")]
 [Api(2)]
 public sealed class WAR_Default : WarriorRotation
@@ -56,11 +56,10 @@ public sealed class WAR_Default : WarriorRotation
         if (UseBurstMedicine(out act)) return true;
 
         if (Player.HasStatus(false, StatusID.SurgingTempest)
-            && !Player.WillStatusEndGCD(2, 0, true, StatusID.SurgingTempest)
+            && !Player.WillStatusEndGCD(6, 0, true, StatusID.SurgingTempest)
             || !MythrilTempestPvE.EnoughLevel)
         {
             if (BerserkPvE.CanUse(out act)) return true;
-
         }
 
         if (IsBurstStatus)
@@ -79,7 +78,6 @@ public sealed class WAR_Default : WarriorRotation
         if (OnslaughtPvE.CanUse(out act, usedUp: IsBurstStatus) &&
            !IsMoving &&
            !IsLastAction(true, OnslaughtPvE) &&
-           !IsLastAction(true, UpheavalPvE) &&
             Player.HasStatus(false, StatusID.SurgingTempest))
         {
             return true;
@@ -150,26 +148,24 @@ public sealed class WAR_Default : WarriorRotation
             if (FellCleavePvE.CanUse(out act, skipStatusProvideCheck: true)) return true;
         }
 
-        if (Player.HasStatus(false, StatusID.SurgingTempest) &&
-       (IsBurstStatus || !Player.HasStatus(false, StatusID.NascentChaos) || BeastGauge > 80))
-        {
-            if (SteelCyclonePvE.CanUse(out act)) return true;
-            if (InnerBeastPvE.CanUse(out act)) return true;
-        }
-
         if (!Player.WillStatusEndGCD(3, 0, true, StatusID.SurgingTempest))
         {
-            if (!IsMoving && PrimalRendPvE.CanUse(out act, skipAoeCheck: true))
-            {
-                if (PrimalRendPvE.Target.Target?.DistanceToPlayer() < 2) return true;
-            }
-
             // New check for Primal Ruination
             if (Player.HasStatus(false, StatusID.PrimalRuinationReady) && !Player.HasStatus(false, StatusID.InnerRelease))
             {
                 if (PrimalRuinationPvE.CanUse(out act, skipAoeCheck: true)) return true;
             }
+            if (!IsMoving && PrimalRendPvE.CanUse(out act, skipAoeCheck: true))
+            {
+                if (PrimalRendPvE.Target.Target?.DistanceToPlayer() < 2) return true;
+            }
 
+
+            if (IsBurstStatus || !Player.HasStatus(false, StatusID.NascentChaos) || BeastGauge > 80)
+            {
+                if (SteelCyclonePvE.CanUse(out act)) return true;
+                if (InnerBeastPvE.CanUse(out act)) return true;
+            }
         }
 
         if (MythrilTempestPvE.CanUse(out act)) return true;

--- a/BasicRotations/Tank/WAR_Default.cs
+++ b/BasicRotations/Tank/WAR_Default.cs
@@ -2,7 +2,7 @@ using RotationSolver.Basic.Data;
 
 namespace DefaultRotations.Tank;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.00", Description = "Additional Contributions from Sascha")]
+[Rotation("Sascha", CombatType.PvE, GameVersion = "7.00", Description = "Additional Contributions from Sascha")]
 [SourceCode(Path = "main/DefaultRotations/Tank/WAR_Default.cs")]
 [Api(2)]
 public sealed class WAR_Default : WarriorRotation
@@ -56,10 +56,11 @@ public sealed class WAR_Default : WarriorRotation
         if (UseBurstMedicine(out act)) return true;
 
         if (Player.HasStatus(false, StatusID.SurgingTempest)
-            && !Player.WillStatusEndGCD(6, 0, true, StatusID.SurgingTempest)
+            && !Player.WillStatusEndGCD(2, 0, true, StatusID.SurgingTempest)
             || !MythrilTempestPvE.EnoughLevel)
         {
             if (BerserkPvE.CanUse(out act)) return true;
+
         }
 
         if (IsBurstStatus)
@@ -78,6 +79,7 @@ public sealed class WAR_Default : WarriorRotation
         if (OnslaughtPvE.CanUse(out act, usedUp: IsBurstStatus) &&
            !IsMoving &&
            !IsLastAction(true, OnslaughtPvE) &&
+           !IsLastAction(true, UpheavalPvE) &&
             Player.HasStatus(false, StatusID.SurgingTempest))
         {
             return true;
@@ -148,24 +150,26 @@ public sealed class WAR_Default : WarriorRotation
             if (FellCleavePvE.CanUse(out act, skipStatusProvideCheck: true)) return true;
         }
 
+        if (Player.HasStatus(false, StatusID.SurgingTempest) &&
+       (IsBurstStatus || !Player.HasStatus(false, StatusID.NascentChaos) || BeastGauge > 80))
+        {
+            if (SteelCyclonePvE.CanUse(out act)) return true;
+            if (InnerBeastPvE.CanUse(out act)) return true;
+        }
+
         if (!Player.WillStatusEndGCD(3, 0, true, StatusID.SurgingTempest))
         {
-            // New check for Primal Ruination
-            if (Player.HasStatus(false, StatusID.PrimalRuinationReady) && !Player.HasStatus(false, StatusID.InnerRelease))
-            {
-                if (PrimalRuinationPvE.CanUse(out act, skipAoeCheck: true)) return true;
-            }
             if (!IsMoving && PrimalRendPvE.CanUse(out act, skipAoeCheck: true))
             {
                 if (PrimalRendPvE.Target.Target?.DistanceToPlayer() < 2) return true;
             }
 
-
-            if (IsBurstStatus || !Player.HasStatus(false, StatusID.NascentChaos) || BeastGauge > 80)
+            // New check for Primal Ruination
+            if (Player.HasStatus(false, StatusID.PrimalRuinationReady) && !Player.HasStatus(false, StatusID.InnerRelease))
             {
-                if (SteelCyclonePvE.CanUse(out act)) return true;
-                if (InnerBeastPvE.CanUse(out act)) return true;
+                if (PrimalRuinationPvE.CanUse(out act, skipAoeCheck: true)) return true;
             }
+
         }
 
         if (MythrilTempestPvE.CanUse(out act)) return true;

--- a/BasicRotations/Tank/WAR_Default.cs
+++ b/BasicRotations/Tank/WAR_Default.cs
@@ -77,7 +77,11 @@ public sealed class WAR_Default : WarriorRotation
 
         if (OnslaughtPvE.CanUse(out act, usedUp: IsBurstStatus) &&
            !IsMoving &&
-           !IsLastAction(true, OnslaughtPvE) &&
+           !IsLastAction(true, OnslaughtPvE) && // avoid clipping with auto heal defensives
+           !IsLastAction(true, EquilibriumPvE) && // avoid clipping with auto heal defensives
+           !IsLastAction(true, NascentFlashPvE) && // avoid clipping with auto heal defensives
+           !IsLastAction(true, ThrillOfBattlePvE) && // avoid clipping with auto heal defensives
+
             Player.HasStatus(false, StatusID.SurgingTempest))
         {
             return true;
@@ -151,13 +155,13 @@ public sealed class WAR_Default : WarriorRotation
         if (!Player.WillStatusEndGCD(3, 0, true, StatusID.SurgingTempest))
         {
             // New check for Primal Ruination
-            if (Player.HasStatus(false, StatusID.PrimalRuinationReady) && !Player.HasStatus(false, StatusID.InnerRelease))
+            if (Player.HasStatus(false, StatusID.PrimalRuinationReady)) // Squeezed ruination into opener for raid buffs = big dps increase
             {
                 if (PrimalRuinationPvE.CanUse(out act, skipAoeCheck: true)) return true;
             }
             if (!IsMoving && PrimalRendPvE.CanUse(out act, skipAoeCheck: true))
             {
-                if (PrimalRendPvE.Target.Target?.DistanceToPlayer() < 2) return true;
+                if (PrimalRendPvE.Target.Target?.DistanceToPlayer() < 1) return true; // back to default
             }
 
 


### PR DESCRIPTION
• Prevent Onslaught clipping with auto heal defensives (might add same lines for Upheaval later, but so far in testing its somehow only a onslaught issue, prolly due to longer animation lock?)

• Onslaught range back to default RSR Value

• Removed my initial Status check which delayed Ruination by roughly 15 seconds bc the opener on release was still a placeholder. Ruination in opener is a big dps increase due to raid buffs which is kinda obvious.


