### PR TITLE
Adusted RDM acceleration/swiftcast/grandimpact usage.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            ./build/RebornRotations.dll
-            ./build/RebornRotations.pdb
+            ./build/LoidShitRotations.dll
+            ./build/LoidShitRotations.pdb
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,16 +31,15 @@ jobs:
           Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\dev"
 
       - name: Restore Nuget Packages
-        run: dotnet restore BasicRotations/RebornRotations.csproj
+        run: dotnet restore Advanced_Rotations/RabbsRotationsNET8.csproj
 
       - name: Build Rotations
-        run: dotnet build --no-restore -c Release BasicRotations/RebornRotations.csproj -p:AssemblyVersion=${{ env.tag }} -p:FileVersion=${{ env.tag }} -p:InformationalVersion=${{ env.tag }} --output .\build
+        run: dotnet build --no-restore -c Release LoidGetRotatedIdiot/LoidShitRotation.csproj -p:AssemblyVersion=${{ env.tag }} -p:FileVersion=${{ env.tag }} -p:InformationalVersion=${{ env.tag }} --output .\build
 
       - name: Publish Rotations
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            ./build/LoidShitRotations.dll
-            ./build/LoidShitRotations.pdb
+            ./build/LoidShitRotation.dll
+            ./build/LoidShitRotation.pdb
           token: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,15 +31,15 @@ jobs:
           Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\dev"
 
       - name: Restore Nuget Packages
-        run: dotnet restore Advanced_Rotations/RabbsRotationsNET8.csproj
+        run: dotnet restore BasicRotations/RebornRotations.csproj
 
       - name: Build Rotations
-        run: dotnet build --no-restore -c Release LoidGetRotatedIdiot/LoidShitRotation.csproj -p:AssemblyVersion=${{ env.tag }} -p:FileVersion=${{ env.tag }} -p:InformationalVersion=${{ env.tag }} --output .\build
+        run: dotnet build --no-restore -c Release BasicRotations/RebornRotations.csproj -p:AssemblyVersion=${{ env.tag }} -p:FileVersion=${{ env.tag }} -p:InformationalVersion=${{ env.tag }} --output .\build
 
       - name: Publish Rotations
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            ./build/LoidShitRotation.dll
-            ./build/LoidShitRotation.pdb
+            ./build/RebornRotations.dll
+            ./build/RebornRotations.pdb
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -138,7 +138,6 @@ public sealed class RDM_Default : RedMageRotation
         //Check if player moving and dont have acceleration buff already to not override it
         if (IsMoving && !Player.HasStatus(true, StatusID.Acceleration) &&
             (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50) &&
-            !CanStartMeleeCombo &&
             //Additional check to NOT INTERRUPT DOUBLE/TRIPLE melee combos
             !IsLastGCD(ActionID.ResolutionPvE) &&
             //Check if player dont have GrandImpact buff

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -102,7 +102,7 @@ public sealed class RDM_Default : RedMageRotation
             // Hardcode grand impact usage (?)
         if (IsLastGCD(ActionID.AccelerationPvE))
         {
-            if (GrandImpactPvE.CanUse(out act, skipAoeCheck: true, skipCastingCheck: Player.HasStatus(true, StatusID.Acceleration))) return true;
+            if (GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: true, skipAoeCheck: true, skipCastingCheck: Player.HasStatus(true, StatusID.Acceleration))) return true;
         }
 
             // Hardcode Resolution & Scorch to avoid double melee without finishers

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -138,7 +138,7 @@ public sealed class RDM_Default : RedMageRotation
         //Check if player moving and dont have acceleration buff already to not override it
         if (IsMoving && !Player.HasStatus(true, StatusID.Acceleration) &&
             //Additional check to NOT INTERRUPT DOUBLE/TRIPLE melee combos
-            !IsLastGCD(ActionID.ResolutionPvE)&&
+            !IsLastGCD(ActionID.ResolutionPvE) &&
             //Check if player dont have GrandImpact buff
             !Player.HasStatus(true, StatusID.GrandImpactReady) &&
             //Fires acceleration. If player dont have acceleration at all, fires swiftcast instead
@@ -146,7 +146,7 @@ public sealed class RDM_Default : RedMageRotation
 
         //Grand impact usage
         if (!IsLastGCD(ActionID.ResolutionPvE) && /*<- additional melee protection, just to be sure*/
-            GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: Player.HasStatus(true, StatusID.GrandImpactReady), skipCastingCheck: true, skipAoeCheck: true)) return true;
+        GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: Player.HasStatus(true, StatusID.GrandImpactReady), skipCastingCheck: true, skipAoeCheck: true)) return true;
 
 
         if (ManaStacks == 3) return false;

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -137,8 +137,8 @@ public sealed class RDM_Default : RedMageRotation
         //Swiftcast and acceleration usage (experimental, old method on line 61)
         //Check if player moving and dont have acceleration buff already to not override it
         if (IsMoving && !Player.HasStatus(true, StatusID.Acceleration) &&
+        //Additional checks to NOT INTERRUPT DOUBLE/TRIPLE melee combos, ANY COMBO
             (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50) &&
-            //Additional check to NOT INTERRUPT DOUBLE/TRIPLE melee combos
             !IsLastGCD(ActionID.ResolutionPvE) &&
             //Check if player dont have GrandImpact buff
             !Player.HasStatus(true, StatusID.GrandImpactReady) &&

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -33,7 +33,6 @@ public sealed class RDM_Default : RedMageRotation
     }
     #endregion
 
-
     #region oGCD Logic
     protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
     {

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -125,7 +125,7 @@ public sealed class RDM_Default : RedMageRotation
         }
         if (ManaStacks > 0 && RipostePvE.CanUse(out act)) return true;
         
-        if (IsMoving && RangedSwordplay && (ReprisePvE.CanUse(out act) || EnchantedReprisePvE.CanUse(out act))) return true;
+        //if (IsMoving && RangedSwordplay && (ReprisePvE.CanUse(out act) || EnchantedReprisePvE.CanUse(out act))) return true;
 
         return base.EmergencyGCD(out act);
     }
@@ -134,7 +134,7 @@ public sealed class RDM_Default : RedMageRotation
     {
         act = null;
 
-        //Swiftcast and acceleration usage (experimental, old method on line 61)
+    //Swiftcast and acceleration usage (experimental, old method on line 61)
         //Check if player moving and dont have acceleration buff already to not override it
         if (IsMoving && !Player.HasStatus(true, StatusID.Acceleration) &&
         //Additional checks to NOT INTERRUPT DOUBLE/TRIPLE melee combos, ANY COMBO
@@ -142,8 +142,18 @@ public sealed class RDM_Default : RedMageRotation
             !IsLastGCD(ActionID.ResolutionPvE) &&
             //Check if player dont have GrandImpact buff
             !Player.HasStatus(true, StatusID.GrandImpactReady) &&
-            //Fires acceleration. If player dont have acceleration at all, fires swiftcast instead
-            (AccelerationPvE.CanUse(out act, usedUp: true) || (!AccelerationPvE.CanUse(out _) && SwiftcastPvE.CanUse(out act))))) return true;
+                //Fires acceleration. If player dont have acceleration at all, fires swiftcast instead
+                (AccelerationPvE.CanUse(out act, usedUp: true) || (!AccelerationPvE.CanUse(out _) && SwiftcastPvE.CanUse(out act))))) return true;
+
+        //Reprise usage logic
+            //Really dirty done basic checks if RSR can do SOMETHING ELSE except Reprise from instacast spells when moving
+            if (IsMoving && !Player.HasStatus(true, StatusID.GrandImpactReady) && 
+            !AccelerationPvE.CanUse(out act) && !SwiftcastPvE.CanUse(out act) && 
+            !Player.HasStatus(true, StatusID.Swiftcast) && !Player.HasStatus(true, StatusID.Acceleration) &&
+            //Protecc against spamming Reprise when player has melee combo ready
+            (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50) &&
+                //Spam reprise when nothing else to use
+                RangedSwordplay && (ReprisePvE.CanUse(out act) || EnchantedReprisePvE.CanUse(out act)))) return true;
 
 
         //Grand impact usage

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -74,7 +74,7 @@ public sealed class RDM_Default : RedMageRotation
         if (ViceOfThornsPvE.CanUse(out act, skipAoeCheck: true)) return true;
         if (PrefulgencePvE.CanUse(out act, skipAoeCheck: true)) return true;
         if (ContreSixtePvE.CanUse(out act, skipAoeCheck: true)) return true;
-        if (GrandImpactPvE.CanUse(out act, skipAoeCheck: true, skipCastingCheck: Player.HasStatus(true, StatusID.Acceleration))) return true;
+        // if (GrandImpactPvE.CanUse(out act, skipAoeCheck: true, skipCastingCheck: Player.HasStatus(true, StatusID.Acceleration))) return true;
         if (FlechePvE.CanUse(out act)) return true;
 
         if (EngagementPvE.CanUse(out act, usedUp: true)) return true;
@@ -99,8 +99,14 @@ public sealed class RDM_Default : RedMageRotation
             if (VerflarePvE.CanUse(out act, skipAoeCheck: true)) return true;
         }
 
-        // Hardcode Resolution & Scorch to avoid double melee without finishers
-        if (IsLastGCD(ActionID.ScorchPvE))
+            // Hardcode grand impact usage (?)
+        if (IsLastGCD(ActionID.AccelerationPvE))
+        {
+            if (GrandImpactPvE.CanUse(out act, skipAoeCheck: true, skipCastingCheck: Player.HasStatus(true, StatusID.Acceleration))) return true;
+        }
+
+            // Hardcode Resolution & Scorch to avoid double melee without finishers
+            if (IsLastGCD(ActionID.ScorchPvE))
         {
             if (ResolutionPvE.CanUse(out act, skipStatusProvideCheck: true, skipAoeCheck: true)) return true;
         }

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -74,7 +74,7 @@ public sealed class RDM_Default : RedMageRotation
         if (ViceOfThornsPvE.CanUse(out act, skipAoeCheck: true)) return true;
         if (PrefulgencePvE.CanUse(out act, skipAoeCheck: true)) return true;
         if (ContreSixtePvE.CanUse(out act, skipAoeCheck: true)) return true;
-        if (GrandImpactPvE.CanUse(out act, skipAoeCheck: true)) return true;
+        if (GrandImpactPvE.CanUse(out act, skipCastingCheck: Player.HasStatus(true, StatusID.Acceleration))) return true;
         if (FlechePvE.CanUse(out act)) return true;
 
         if (EngagementPvE.CanUse(out act, usedUp: true)) return true;

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -74,7 +74,7 @@ public sealed class RDM_Default : RedMageRotation
         if (ViceOfThornsPvE.CanUse(out act, skipAoeCheck: true)) return true;
         if (PrefulgencePvE.CanUse(out act, skipAoeCheck: true)) return true;
         if (ContreSixtePvE.CanUse(out act, skipAoeCheck: true)) return true;
-        if (GrandImpactPvE.CanUse(out act, skipCastingCheck: Player.HasStatus(true, StatusID.Acceleration))) return true;
+        if (GrandImpactPvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true, Player.HasStatus(true, StatusID.Acceleration))) return true;
         if (FlechePvE.CanUse(out act)) return true;
 
         if (EngagementPvE.CanUse(out act, usedUp: true)) return true;
@@ -135,8 +135,6 @@ public sealed class RDM_Default : RedMageRotation
     {
         act = null;
         if (ManaStacks == 3) return false;
-        
-        if (GrandImpactPvE.CanUse(out act)) return true;
         
         if (!VerthunderIiPvE.CanUse(out _))
         {

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -33,6 +33,7 @@ public sealed class RDM_Default : RedMageRotation
     }
     #endregion
 
+
     #region oGCD Logic
     protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
     {

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -74,6 +74,7 @@ public sealed class RDM_Default : RedMageRotation
         if (ViceOfThornsPvE.CanUse(out act, skipAoeCheck: true)) return true;
         if (PrefulgencePvE.CanUse(out act, skipAoeCheck: true)) return true;
         if (ContreSixtePvE.CanUse(out act, skipAoeCheck: true)) return true;
+        if (GrandImpactPvE.CanUse(out act, skipAoeCheck: true)) return true;
         if (FlechePvE.CanUse(out act)) return true;
 
         if (EngagementPvE.CanUse(out act, usedUp: true)) return true;

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -99,13 +99,7 @@ public sealed class RDM_Default : RedMageRotation
             if (VerflarePvE.CanUse(out act, skipAoeCheck: true)) return true;
         }
 
-            // Hardcode grand impact usage (?)
-        if (IsLastGCD(ActionID.AccelerationPvE))
-        {
-            if (GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: true, skipAoeCheck: true, skipCastingCheck: Player.HasStatus(true, StatusID.Acceleration))) return true;
-        }
-
-            // Hardcode Resolution & Scorch to avoid double melee without finishers
+           // Hardcode Resolution & Scorch to avoid double melee without finishers
             if (IsLastGCD(ActionID.ScorchPvE))
         {
             if (ResolutionPvE.CanUse(out act, skipStatusProvideCheck: true, skipAoeCheck: true)) return true;
@@ -133,6 +127,12 @@ public sealed class RDM_Default : RedMageRotation
         if (ManaStacks > 0 && RipostePvE.CanUse(out act)) return true;
         
         if (IsMoving && RangedSwordplay && (ReprisePvE.CanUse(out act) || EnchantedReprisePvE.CanUse(out act))) return true;
+
+        // Hardcode grand impact usage (?)
+        if (IsLastAction(ActionID.AccelerationPvE))
+        {
+            if (GrandImpactPvE.CanUse(out act, skipAoeCheck: true, skipCastingCheck: Player.HasStatus(true, StatusID.Acceleration))) return true;
+        }
 
         return base.EmergencyGCD(out act);
     }

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -134,15 +134,17 @@ public sealed class RDM_Default : RedMageRotation
     {
         act = null;
 
-      //Swiftcast and acceleration usage (experimental, old method on line 61)
+        //Swiftcast and acceleration usage (experimental, old method on line 61)
         //Check if player moving and dont have acceleration buff already to not override it
         if (IsMoving && !Player.HasStatus(true, StatusID.Acceleration) &&
+            (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50) &&
             //Additional check to NOT INTERRUPT DOUBLE/TRIPLE melee combos
             !IsLastGCD(ActionID.ResolutionPvE) &&
             //Check if player dont have GrandImpact buff
             !Player.HasStatus(true, StatusID.GrandImpactReady) &&
             //Fires acceleration. If player dont have acceleration at all, fires swiftcast instead
-            (AccelerationPvE.CanUse(out act, usedUp: true) || (!AccelerationPvE.CanUse(out _) && SwiftcastPvE.CanUse(out act)))) return true;
+            (AccelerationPvE.CanUse(out act, usedUp: true) || (!AccelerationPvE.CanUse(out _) && SwiftcastPvE.CanUse(out act))))) return true;
+
 
         //Grand impact usage
         if (!IsLastGCD(ActionID.ResolutionPvE) && /*<- additional melee protection, just to be sure*/

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -138,6 +138,7 @@ public sealed class RDM_Default : RedMageRotation
         //Check if player moving and dont have acceleration buff already to not override it
         if (IsMoving && !Player.HasStatus(true, StatusID.Acceleration) &&
             (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50) &&
+            !CanStartMeleeCombo &&
             //Additional check to NOT INTERRUPT DOUBLE/TRIPLE melee combos
             !IsLastGCD(ActionID.ResolutionPvE) &&
             //Check if player dont have GrandImpact buff

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -129,7 +129,7 @@ public sealed class RDM_Default : RedMageRotation
         if (IsMoving && RangedSwordplay && (ReprisePvE.CanUse(out act) || EnchantedReprisePvE.CanUse(out act))) return true;
 
         // Hardcode grand impact usage (?)
-        if (IsLastAction(ActionID.AccelerationPvE))
+        if (IsLastGCD(ActionID.AccelerationPvE))
         {
             if (GrandImpactPvE.CanUse(out act, skipCastingCheck: Player.HasStatus(true, StatusID.Acceleration), skipAoeCheck: true)) return true;
         }

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -131,7 +131,7 @@ public sealed class RDM_Default : RedMageRotation
         // Hardcode grand impact usage (?)
         if (IsLastAction(ActionID.AccelerationPvE))
         {
-            if (GrandImpactPvE.CanUse(out act, skipAoeCheck: true, skipCastingCheck: Player.HasStatus(true, StatusID.Acceleration))) return true;
+            if (GrandImpactPvE.CanUse(out act, skipCastingCheck: Player.HasStatus(true, StatusID.Acceleration), skipAoeCheck: true)) return true;
         }
 
         return base.EmergencyGCD(out act);

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -74,7 +74,7 @@ public sealed class RDM_Default : RedMageRotation
         if (ViceOfThornsPvE.CanUse(out act, skipAoeCheck: true)) return true;
         if (PrefulgencePvE.CanUse(out act, skipAoeCheck: true)) return true;
         if (ContreSixtePvE.CanUse(out act, skipAoeCheck: true)) return true;
-        if (GrandImpactPvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true, Player.HasStatus(true, StatusID.Acceleration))) return true;
+        if (GrandImpactPvE.CanUse(out act, skipAoeCheck: true, skipCastingCheck: Player.HasStatus(true, StatusID.Acceleration))) return true;
         if (FlechePvE.CanUse(out act)) return true;
 
         if (EngagementPvE.CanUse(out act, usedUp: true)) return true;

--- a/README.md
+++ b/README.md
@@ -1,15 +1,1 @@
-# To be used with [RotationSolverReborn](https://github.com/FFXIV-CombatReborn/RotationSolverReborn)
-![GitHub all releases](https://img.shields.io/github/downloads/FFXIV-CombatReborn/RebornRotations/total)
-
-Download the latest version of RebornRotations:
-
-- [`RebornRotations.dll`](https://github.com/FFXIV-CombatReborn/RebornRotations/releases/latest/download/RebornRotations.dll)
-
-```
-https://github.com/FFXIV-CombatReborn/RebornRotations/releases/latest/download/RebornRotations.dll
-```
-- [`RebornRotations.pdb`](https://github.com/FFXIV-CombatReborn/RebornRotations/releases/latest/download/RebornRotations.pdb)
-
-```
-https://github.com/FFXIV-CombatReborn/RebornRotations/releases/latest/download/RebornRotations.pdb
-```
+Idk what the fuck im a doing


### PR DESCRIPTION
RDM now uses acceleration/swiftcast if player moves.
Also, it uses grand impact after acceleration.
Also also, for now, it will not use acceleration/switftcast if player have 50/50 mana for melee combo, will work around that (in case if player outside of melee range to use combo).

And, im new to github/coding etc etc, sorry for bunch of commits, just look at files changed. xD