### PR TITLE
RDM additional logic

### DIFF
--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -135,8 +135,7 @@ public sealed class RDM_Default : RedMageRotation
         bool didWeJustCombo = IsLastGCD([
             ActionID.ScorchPvE, ActionID.VerflarePvE, ActionID.VerholyPvE, ActionID.ZwerchhauPvE,
             ActionID.RedoublementPvE]);
-
-
+        //Grand impact usage if not interrupting melee combo
         if (!didWeJustCombo && GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: Player.HasStatus(true, StatusID.GrandImpactReady), skipCastingCheck:true, skipAoeCheck: true)) return true;
 
         //Acceleration/Swiftcast usage on move
@@ -152,7 +151,7 @@ public sealed class RDM_Default : RedMageRotation
         {
             return true;
         }
-        
+
          //Reprise logic
         if (IsMoving && RangedSwordplay && !didWeJustCombo &&
             //Check to not use Reprise when player can do melee combo

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -126,13 +126,37 @@ public sealed class RDM_Default : RedMageRotation
         if (ManaStacks > 0 && RipostePvE.CanUse(out act)) return true;
         
         if (IsMoving && RangedSwordplay && (ReprisePvE.CanUse(out act) || EnchantedReprisePvE.CanUse(out act))) return true;
+<<<<<<< Updated upstream
 
+=======
+        
+>>>>>>> Stashed changes
         return base.EmergencyGCD(out act);
     }
 
     protected override bool GeneralGCD(out IAction? act)
     {
         act = null;
+<<<<<<< Updated upstream
+=======
+
+        //Swiftcast and acceleration usage (experimental, old method on line 61)
+        //Check if player moving and dont have acceleration buff already to not override it
+        if (IsMoving && !Player.HasStatus(true, StatusID.Acceleration) &&
+        //Additional checks to NOT INTERRUPT DOUBLE/TRIPLE melee combos, ANY COMBO
+            (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50) &&
+            !IsLastGCD(ActionID.ResolutionPvE) &&
+            //Check if player dont have GrandImpact buff
+            !Player.HasStatus(true, StatusID.GrandImpactReady) &&
+            //Fires acceleration. If player dont have acceleration at all, fires swiftcast instead
+            (AccelerationPvE.CanUse(out act, usedUp: true) || (!AccelerationPvE.CanUse(out _) && SwiftcastPvE.CanUse(out act))))) return true;
+
+        //Grand impact usage
+        if (!IsLastGCD(ActionID.ResolutionPvE) && /*<- additional melee protection, just to be sure*/
+        GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: Player.HasStatus(true, StatusID.GrandImpactReady), skipCastingCheck: true, skipAoeCheck: true)) return true;
+
+
+>>>>>>> Stashed changes
         if (ManaStacks == 3) return false;
         
         if (GrandImpactPvE.CanUse(out act)) return true;

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -126,19 +126,13 @@ public sealed class RDM_Default : RedMageRotation
         if (ManaStacks > 0 && RipostePvE.CanUse(out act)) return true;
         
         if (IsMoving && RangedSwordplay && (ReprisePvE.CanUse(out act) || EnchantedReprisePvE.CanUse(out act))) return true;
-<<<<<<< Updated upstream
-
-=======
         
->>>>>>> Stashed changes
         return base.EmergencyGCD(out act);
     }
 
     protected override bool GeneralGCD(out IAction? act)
     {
         act = null;
-<<<<<<< Updated upstream
-=======
 
         //Swiftcast and acceleration usage (experimental, old method on line 61)
         //Check if player moving and dont have acceleration buff already to not override it
@@ -155,8 +149,6 @@ public sealed class RDM_Default : RedMageRotation
         if (!IsLastGCD(ActionID.ResolutionPvE) && /*<- additional melee protection, just to be sure*/
         GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: Player.HasStatus(true, StatusID.GrandImpactReady), skipCastingCheck: true, skipAoeCheck: true)) return true;
 
-
->>>>>>> Stashed changes
         if (ManaStacks == 3) return false;
         
         if (GrandImpactPvE.CanUse(out act)) return true;


### PR DESCRIPTION
Added additional logic to acceleration/swiftcast usage, they will not overwrite each other anymore (mostly).
After each acceleration grand impact will be used.

Added aditional logic to reprise usage, now rotation prioritize ANYTHING (acceleartion/swiftcast/any spells that can be instacasted) instead of reprise, also, added check if player have 50/50 mana - reprise not will be used to not break ready melee combo.