### PR TITLE
RDM improved logic

### DIFF
--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -57,8 +57,8 @@ public sealed class RDM_Default : RedMageRotation
 
     protected override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
-        //Swift
-        if (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50)
+        //Swiftcast/Acceleration usage OLD VERSION
+       /* if (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50)
             && (CombatElapsedLess(4) || !ManaficationPvE.EnoughLevel || !ManaficationPvE.Cooldown.WillHaveOneChargeGCD(0, 1)))
         {
             if (InCombat && !Player.HasStatus(true, StatusID.VerfireReady, StatusID.VerstoneReady))
@@ -66,7 +66,7 @@ public sealed class RDM_Default : RedMageRotation
                 if (SwiftcastPvE.CanUse(out act)) return true;
                 if (AccelerationPvE.CanUse(out act, usedUp: true)) return true;
             }
-        }
+        }*/
 
         if (IsBurst && UseBurstMedicine(out act)) return true;
 
@@ -138,8 +138,8 @@ public sealed class RDM_Default : RedMageRotation
         //Grand impact usage if not interrupting melee combo
         if (!didWeJustCombo && GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: Player.HasStatus(true, StatusID.GrandImpactReady), skipCastingCheck:true, skipAoeCheck: true)) return true;
 
-        //Acceleration/Swiftcast usage on move
-        if (IsMoving && 
+        //Acceleration/Swiftcast usage on move, old method on line 61.
+        if (IsMoving && !Player.HasStatus(true, StatusID.Dualcast) &&
             //Checks for not override previous acceleration and lose grand impact
             !Player.HasStatus(true, StatusID.Acceleration) && 
             !Player.HasStatus(true, StatusID.GrandImpactReady) &&
@@ -154,7 +154,7 @@ public sealed class RDM_Default : RedMageRotation
 
          //Reprise logic
         if (IsMoving && RangedSwordplay && !didWeJustCombo &&
-            //Check to not use Reprise when player can do melee combo
+            //Check to not use Reprise when player can do melee combo, to not break it
             (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50) &&
             //Check if dualcast active
             !Player.HasStatus(true, StatusID.Dualcast) &&

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -135,8 +135,7 @@ public sealed class RDM_Default : RedMageRotation
         bool didWeJustCombo = IsLastGCD([
             ActionID.ScorchPvE, ActionID.VerflarePvE, ActionID.VerholyPvE, ActionID.ZwerchhauPvE,
             ActionID.RedoublementPvE]);
-
-
+        //Grand impact usage if not interrupting melee combo
         if (!didWeJustCombo && GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: Player.HasStatus(true, StatusID.GrandImpactReady), skipCastingCheck:true, skipAoeCheck: true)) return true;
 
         //Acceleration/Swiftcast usage on move
@@ -152,7 +151,7 @@ public sealed class RDM_Default : RedMageRotation
         {
             return true;
         }
-        
+
          //Reprise logic
         if (IsMoving && RangedSwordplay && !didWeJustCombo &&
             //Check to not use Reprise when player can do melee combo

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -126,13 +126,37 @@ public sealed class RDM_Default : RedMageRotation
         if (ManaStacks > 0 && RipostePvE.CanUse(out act)) return true;
         
         if (IsMoving && RangedSwordplay && (ReprisePvE.CanUse(out act) || EnchantedReprisePvE.CanUse(out act))) return true;
+<<<<<<< Updated upstream
 
+=======
+        
+>>>>>>> Stashed changes
         return base.EmergencyGCD(out act);
     }
 
     protected override bool GeneralGCD(out IAction? act)
     {
         act = null;
+<<<<<<< Updated upstream
+=======
+
+        //Swiftcast and acceleration usage (experimental, old method on line 61)
+        //Check if player moving and dont have acceleration buff already to not override it
+        if (IsMoving && !Player.HasStatus(true, StatusID.Acceleration) &&
+        //Additional checks to NOT INTERRUPT DOUBLE/TRIPLE melee combos, ANY COMBO
+            (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50) &&
+            !IsLastGCD(ActionID.ResolutionPvE) &&
+            //Check if player dont have GrandImpact buff
+            !Player.HasStatus(true, StatusID.GrandImpactReady) &&
+            //Fires acceleration. If player dont have acceleration at all, fires swiftcast instead
+            (AccelerationPvE.CanUse(out act, usedUp: true) || (!AccelerationPvE.CanUse(out _) && SwiftcastPvE.CanUse(out act))))) return true;
+
+        //Grand impact usage
+        if (!IsLastGCD(ActionID.ResolutionPvE) && /*<- additional melee protection, just to be sure*/
+        GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: Player.HasStatus(true, StatusID.GrandImpactReady), skipCastingCheck: true, skipAoeCheck: true)) return true;
+
+
+>>>>>>> Stashed changes
         if (ManaStacks == 3) return false;
         
         if (GrandImpactPvE.CanUse(out act)) return true;

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -126,19 +126,13 @@ public sealed class RDM_Default : RedMageRotation
         if (ManaStacks > 0 && RipostePvE.CanUse(out act)) return true;
         
         if (IsMoving && RangedSwordplay && (ReprisePvE.CanUse(out act) || EnchantedReprisePvE.CanUse(out act))) return true;
-<<<<<<< Updated upstream
-
-=======
         
->>>>>>> Stashed changes
         return base.EmergencyGCD(out act);
     }
 
     protected override bool GeneralGCD(out IAction? act)
     {
         act = null;
-<<<<<<< Updated upstream
-=======
 
         //Swiftcast and acceleration usage (experimental, old method on line 61)
         //Check if player moving and dont have acceleration buff already to not override it
@@ -155,8 +149,6 @@ public sealed class RDM_Default : RedMageRotation
         if (!IsLastGCD(ActionID.ResolutionPvE) && /*<- additional melee protection, just to be sure*/
         GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: Player.HasStatus(true, StatusID.GrandImpactReady), skipCastingCheck: true, skipAoeCheck: true)) return true;
 
-
->>>>>>> Stashed changes
         if (ManaStacks == 3) return false;
         
         if (GrandImpactPvE.CanUse(out act)) return true;

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -133,8 +133,8 @@ public sealed class RDM_Default : RedMageRotation
         act = null;
 
         bool didWeJustCombo = IsLastGCD([
-            ActionID.ScorchPvE, ActionID.VerflarePvE, ActionID.VerholyPvE, ActionID.ZwerchhauPvE,
-            ActionID.RedoublementPvE]);
+            ActionID.ScorchPvE, ActionID.VerflarePvE, ActionID.VerholyPvE, ActionID.EnchantedZwerchhauPvE,
+            ActionID.EnchantedRedoublementPvP, ActionID.EnchantedRipostePvE]);
         //Grand impact usage if not interrupting melee combo
         if (!didWeJustCombo && GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: Player.HasStatus(true, StatusID.GrandImpactReady), skipCastingCheck:true, skipAoeCheck: true)) return true;
 


### PR DESCRIPTION
Added additional logic to acceleration/swiftcast usage, they will not overwrite each other anymore.
After each acceleration grand impact will be used.

Added aditional logic to reprise usage, now rotation prioritize ANYTHING (acceleration/swiftcast/any spells that can be instacasted) instead of reprise, also, added check if player have 50/50 mana - reprise not will be used to not break ready melee combo.