### PR TITLE
Balance Level 100 Opener

### DIFF
--- a/BasicRotations/Tank/GNB_Default.cs
+++ b/BasicRotations/Tank/GNB_Default.cs
@@ -79,7 +79,7 @@ public sealed class GNB_Default : GunbreakerRotation
             if (!Player.HasStatus(true, StatusID.NoMercy) && !GnashingFangPvE.Cooldown.WillHaveOneCharge(20)) return true;
         }
 
-        if (Player.HasStatus(true, StatusID.NoMercy) && CanUseBowShock(out act)) return true;
+        if (Player.HasStatus(true, StatusID.NoMercy) && IsLastGCD(ActionID.SonicBreakPvE) && CanUseBowShock(out act)) return true;
 
         //if (TrajectoryPvE.CanUse(out act) && !IsMoving) return true;
         if (GnashingFangPvE.Cooldown.IsCoolingDown && DoubleDownPvE.Cooldown.IsCoolingDown && Ammo == 0 && BloodfestPvE.CanUse(out act)) return true;
@@ -98,34 +98,36 @@ public sealed class GNB_Default : GunbreakerRotation
     {
         bool areDDTargetsInRange = AllHostileTargets.Any(hostile => hostile.DistanceToPlayer() < 4.5f);
 
+        if (Player.HasStatus(true, StatusID.NoMercy) && BloodfestPvE.CanUse(out act)) return true;
+
         if (IsLastGCD(false, NobleBloodPvE) && LionHeartPvE.CanUse(out act, skipComboCheck: true)) return true;
         if (IsLastGCD(false, ReignOfBeastsPvE) && NobleBloodPvE.CanUse(out act, skipComboCheck: true)) return true;
-        if (ReignOfBeastsPvE.CanUse(out act)) return true;
+        if (IsLastAction(false, EyeGougePvE) && ReignOfBeastsPvE.CanUse(out act)) return true;
 
-        if (FatedCirclePvE.CanUse(out act)) return true;
-
-        if (CanUseGnashingFang(out act)) return true;
-
-        if (DemonSlaughterPvE.CanUse(out act)) return true;
-        if (DemonSlicePvE.CanUse(out act)) return true;
-
-        if (Player.HasStatus(true, StatusID.NoMercy) && CanUseSonicBreak(out act)) return true;
-
+        if (Player.HasStatus(true, StatusID.NoMercy) && SonicBreakPvE.CanUse(out act)) return true;
+        
         if (areDDTargetsInRange)
         {
             if (Player.HasStatus(true, StatusID.NoMercy) && CanUseDoubleDown(out act)) return true;
+            if (Player.HasStatus(true, StatusID.NoMercy) && BlastingZonePvE.CanUse(out act)) return true;
         }
+        
+        if (CanUseGnashingFang(out act)) return true;
 
         if (SavageClawPvE.CanUse(out act, skipComboCheck: true)) return true;
         if (WickedTalonPvE.CanUse(out act, skipComboCheck: true)) return true;
 
         if (CanUseBurstStrike(out act)) return true;
+        
+        if (FatedCirclePvE.CanUse(out act)) return true;
+        if (DemonSlaughterPvE.CanUse(out act)) return true;
+        if (DemonSlicePvE.CanUse(out act)) return true;
 
+        if (Ammo == 3 && IsLastGCD(ActionID.BrutalShellPvE) && BurstStrikePvE.CanUse(out act)) return true;
+        
         if (SolidBarrelPvE.CanUse(out act)) return true;
         if (BrutalShellPvE.CanUse(out act)) return true;
         if (KeenEdgePvE.CanUse(out act)) return true;
-
-
 
         if (LightningShotPvE.CanUse(out act)) return true;
 
@@ -161,13 +163,12 @@ public sealed class GNB_Default : GunbreakerRotation
     {
         if (GnashingFangPvE.CanUse(out act))
         {
-            if (DemonSlicePvE.CanUse(out _)) return false;
 
-            if (Ammo == MaxAmmo && (Player.HasStatus(true, StatusID.NoMercy) || !NoMercyPvE.Cooldown.WillHaveOneCharge(55))) return true;
+            if (Player.HasStatus(true, StatusID.NoMercy) || !NoMercyPvE.Cooldown.WillHaveOneCharge(55)) return true;
 
             if (Ammo > 0 && !NoMercyPvE.Cooldown.WillHaveOneCharge(17) && NoMercyPvE.Cooldown.WillHaveOneCharge(35)) return true;
 
-            if (Ammo == 3 && IsLastGCD((ActionID)BrutalShellPvE.ID) && NoMercyPvE.Cooldown.WillHaveOneCharge(3)) return true;
+            if (Ammo <= 3 && IsLastGCD((ActionID)BrutalShellPvE.ID) && NoMercyPvE.Cooldown.WillHaveOneCharge(3)) return true;
 
             if (Ammo == 1 && !NoMercyPvE.Cooldown.WillHaveOneCharge(55) && BloodfestPvE.Cooldown.WillHaveOneCharge(5)) return true;
 
@@ -180,11 +181,8 @@ public sealed class GNB_Default : GunbreakerRotation
     {
         if (SonicBreakPvE.CanUse(out act))
         {
-            if (DemonSlicePvE.CanUse(out _)) return false;
-
+            
             if (!GnashingFangPvE.EnoughLevel && Player.HasStatus(true, StatusID.NoMercy)) return true;
-
-            if (GnashingFangPvE.Cooldown.IsCoolingDown && Player.HasStatus(true, StatusID.NoMercy)) return true;
 
             if (!DoubleDownPvE.EnoughLevel && Player.HasStatus(true, StatusID.ReadyToRip)
                 && GnashingFangPvE.Cooldown.IsCoolingDown) return true;
@@ -197,11 +195,7 @@ public sealed class GNB_Default : GunbreakerRotation
     {
         if (DoubleDownPvE.CanUse(out act, skipAoeCheck: true))
         {
-
-            if (DemonSlicePvE.CanUse(out _) && Player.HasStatus(true, StatusID.NoMercy)) return true;
-
             if (SonicBreakPvE.Cooldown.IsCoolingDown && Player.HasStatus(true, StatusID.NoMercy)) return true;
-
             if (Player.HasStatus(true, StatusID.NoMercy) && !NoMercyPvE.Cooldown.WillHaveOneCharge(55) && BloodfestPvE.Cooldown.WillHaveOneCharge(5)) return true;
 
         }
@@ -212,7 +206,7 @@ public sealed class GNB_Default : GunbreakerRotation
     {
         if (BurstStrikePvE.CanUse(out act))
         {
-            if (DemonSlicePvE.CanUse(out _)) return false;
+            if (DemonSlicePvE.CanUse(out act)) return false;
 
             if (SonicBreakPvE.Cooldown.IsCoolingDown && SonicBreakPvE.Cooldown.WillHaveOneCharge(0.5f) && GnashingFangPvE.EnoughLevel) return false;
 

--- a/BasicRotations/Tank/GNB_Default.cs
+++ b/BasicRotations/Tank/GNB_Default.cs
@@ -68,8 +68,9 @@ public sealed class GNB_Default : GunbreakerRotation
 
         if (JugularRipPvE.CanUse(out act)) return true;
 
-        if (DangerZonePvE.CanUse(out act))
+        if (DangerZonePvE.CanUse(out act) && !DoubleDownPvE.EnoughLevel)
         {
+            
             if (!IsFullParty && !(DangerZonePvE.Target.Target?.IsBossFromTTK() ?? false)) return true;
 
             if (!GnashingFangPvE.EnoughLevel && (Player.HasStatus(true, StatusID.NoMercy) || !NoMercyPvE.Cooldown.WillHaveOneCharge(15))) return true;
@@ -79,7 +80,7 @@ public sealed class GNB_Default : GunbreakerRotation
             if (!Player.HasStatus(true, StatusID.NoMercy) && !GnashingFangPvE.Cooldown.WillHaveOneCharge(20)) return true;
         }
 
-        if (Player.HasStatus(true, StatusID.NoMercy) && IsLastGCD(ActionID.SonicBreakPvE) && CanUseBowShock(out act)) return true;
+        if (Player.HasStatus(true, StatusID.NoMercy) && CanUseBowShock(out act)) return true;
 
         //if (TrajectoryPvE.CanUse(out act) && !IsMoving) return true;
         if (GnashingFangPvE.Cooldown.IsCoolingDown && DoubleDownPvE.Cooldown.IsCoolingDown && Ammo == 0 && BloodfestPvE.CanUse(out act)) return true;
@@ -109,8 +110,10 @@ public sealed class GNB_Default : GunbreakerRotation
         if (areDDTargetsInRange)
         {
             if (Player.HasStatus(true, StatusID.NoMercy) && CanUseDoubleDown(out act)) return true;
-            if (Player.HasStatus(true, StatusID.NoMercy) && BlastingZonePvE.CanUse(out act)) return true;
+            if (Player.HasStatus(true, StatusID.NoMercy) && IsLastGCD(ActionID.DoubleDownPvE) && BlastingZonePvE.CanUse(out act)) return true;
         }
+
+        
         
         if (CanUseGnashingFang(out act)) return true;
 
@@ -163,6 +166,8 @@ public sealed class GNB_Default : GunbreakerRotation
     {
         if (GnashingFangPvE.CanUse(out act))
         {
+            //AOE Check: Mobs = NO, Boss = YES
+            if (DemonSlicePvE.CanUse(out _)) return false;
 
             if (Player.HasStatus(true, StatusID.NoMercy) || !NoMercyPvE.Cooldown.WillHaveOneCharge(55)) return true;
 
@@ -177,7 +182,7 @@ public sealed class GNB_Default : GunbreakerRotation
         return false;
     }
 
-    private bool CanUseSonicBreak(out IAction act)
+    /*private bool CanUseSonicBreak(out IAction act)
     {
         if (SonicBreakPvE.CanUse(out act))
         {
@@ -189,7 +194,7 @@ public sealed class GNB_Default : GunbreakerRotation
 
         }
         return false;
-    }
+    }*/
 
     private bool CanUseDoubleDown(out IAction? act)
     {
@@ -228,6 +233,7 @@ public sealed class GNB_Default : GunbreakerRotation
     {
         if (BowShockPvE.CanUse(out act, skipAoeCheck: true))
         {
+            //AOE CHECK
             if (DemonSlicePvE.CanUse(out _) && !IsFullParty) return true;
 
             if (!SonicBreakPvE.EnoughLevel && Player.HasStatus(true, StatusID.NoMercy)) return true;


### PR DESCRIPTION
- Balance Opener Lvl 100 2.50GCD
- Fixed Reign Combo Interrupting Gnashing Fang
- WIll prevent overcap in basic filler combo
- WIl Use No Mercy + Bloodfest if it can for burst

Tested on:
- Level 30 Dungeon
- Level 50 Dungeon
- Level 60 Dungeon
- Level 70 Dungeon
- Level 80 Dungeon
- Level 90 Dungeon

![2 50 GNB](https://github.com/user-attachments/assets/b20a4941-ed44-4096-82f9-2ecdf933893e)

