### PR TITLE
Better XIVAnalysis

### DIFF
--- a/BasicRotations/Tank/GNB_Default.cs
+++ b/BasicRotations/Tank/GNB_Default.cs
@@ -112,8 +112,8 @@ public sealed class GNB_Default : GunbreakerRotation
             if (Player.HasStatus(true, StatusID.NoMercy) && CanUseDoubleDown(out act)) return true;
             if (Player.HasStatus(true, StatusID.NoMercy) && IsLastGCD(ActionID.DoubleDownPvE) && BlastingZonePvE.CanUse(out act)) return true;
         }
-
-        
+    
+        if (NoMercyPvE.Cooldown.IsCoolingDown && BloodfestPvE.Cooldown.IsCoolingDown && BlastingZonePvE.CanUse(out act)) return true;
         
         if (CanUseGnashingFang(out act)) return true;
 
@@ -126,7 +126,7 @@ public sealed class GNB_Default : GunbreakerRotation
         if (DemonSlaughterPvE.CanUse(out act)) return true;
         if (DemonSlicePvE.CanUse(out act)) return true;
 
-        if (Ammo == 3 && IsLastGCD(ActionID.BrutalShellPvE) && BurstStrikePvE.CanUse(out act)) return true;
+        if (Ammo == 2 && IsLastGCD(ActionID.BrutalShellPvE) && BurstStrikePvE.CanUse(out act)) return true;
         
         if (SolidBarrelPvE.CanUse(out act)) return true;
         if (BrutalShellPvE.CanUse(out act)) return true;


### PR DESCRIPTION
- Fixed Cartridge Usage 30/32 (stopped log with 2 cartridges left)
- Fixed always be casting 98.4% (green)
- Fixed Use all your cooldowns 98.6 (green)
- Fixed Use your continuation spells 100% (green)