### PR TITLE
RDM additional logic / Fix for AOE melee combo

### DIFF
--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -108,7 +108,9 @@ public sealed class RDM_Default : RedMageRotation
               ActionID.MoulinetPvE,
               ActionID.EnchantedMoulinetPvE
           });
-    
+
+        //Acceleration usage on combo with saving 1 charge for movement
+        if (!checkmelee && AccelerationPvE.CanUse(out act)) return true;
     
         //Acceleration/Swiftcast usage on move
         if (IsMoving && !Player.HasStatus(true, StatusID.Dualcast) && !checkmelee &&

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -39,7 +39,9 @@ public sealed class RDM_Default : RedMageRotation
 
     #region oGCD Logic
     protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
-    {
+    {   
+        
+        //COMMENT FOR MYSELF FROM FUTURE - WHY THE FUCK EMBOLDEN DONT WORK WITHOUT skipAoeCheck: true???
         bool AnyoneInRange = AllHostileTargets.Any(hostile => hostile.DistanceToPlayer() <= 4);
         
         act = null;
@@ -69,15 +71,15 @@ public sealed class RDM_Default : RedMageRotation
     protected override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
         //Swiftcast/Acceleration usage OLD VERSION
-       /* if (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50)
-            && (CombatElapsedLess(4) || !ManaficationPvE.EnoughLevel || !ManaficationPvE.Cooldown.WillHaveOneChargeGCD(0, 1)))
-        {
-            if (InCombat && !Player.HasStatus(true, StatusID.VerfireReady, StatusID.VerstoneReady))
-            {
-                if (SwiftcastPvE.CanUse(out act)) return true;
-                if (AccelerationPvE.CanUse(out act, usedUp: true)) return true;
-            }
-        }*/
+       // if (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50)
+       //      && (CombatElapsedLess(4) || !ManaficationPvE.EnoughLevel || !ManaficationPvE.Cooldown.WillHaveOneChargeGCD(0, 1)))
+       //  {
+       //      if (InCombat && !Player.HasStatus(true, StatusID.VerfireReady, StatusID.VerstoneReady))
+       //      {
+       //          if (SwiftcastPvE.CanUse(out act)) return true;
+       //          if (AccelerationPvE.CanUse(out act, usedUp: true)) return true;
+       //      }
+       //  }
 
         if (IsBurst && UseBurstMedicine(out act)) return true;
 
@@ -121,10 +123,10 @@ public sealed class RDM_Default : RedMageRotation
         }
 
         //Melee AOE combo
-        if (IsLastGCD(true, EnchantedMoulinetPvE) && EnchantedMoulinetDeuxPvE.CanUse(out act)) return true;
         if (IsLastGCD(true, EnchantedMoulinetDeuxPvE) && EnchantedMoulinetTroisPvE.CanUse(out act)) return true;
-        if (EnchantedZwerchhauPvE.CanUse(out act)) return true;
+        if (IsLastGCD(true, EnchantedMoulinetPvE) && EnchantedMoulinetDeuxPvE.CanUse(out act)) return true;
         if (EnchantedRedoublementPvE.CanUse(out act)) return true;
+        if (EnchantedZwerchhauPvE.CanUse(out act)) return true;
 
         if (!CanStartMeleeCombo) return false;
 

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -20,8 +20,8 @@ public sealed class RDM_Default : RedMageRotation
     public bool AnyonesMeleeRule { get; set; } = false;
 
     //Fine, ill do it myself
-      [RotationConfig(CombatType.PvE, Name = "Cast manafication outside of embolden window (use at own risk).")]
-      public bool AnyoneManafication { get; set; } = false;
+    [RotationConfig(CombatType.PvE, Name = "Cast manafication outside of embolden window (use at own risk).")]
+    public bool AnyoneManafication { get; set; } = false;
     #endregion
 
     #region Countdown Logic

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -57,8 +57,8 @@ public sealed class RDM_Default : RedMageRotation
 
     protected override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
-        //Swift
-        if (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50)
+        //Swiftcast/Acceleration usage OLD VERSION
+       /* if (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50)
             && (CombatElapsedLess(4) || !ManaficationPvE.EnoughLevel || !ManaficationPvE.Cooldown.WillHaveOneChargeGCD(0, 1)))
         {
             if (InCombat && !Player.HasStatus(true, StatusID.VerfireReady, StatusID.VerstoneReady))
@@ -66,7 +66,7 @@ public sealed class RDM_Default : RedMageRotation
                 if (SwiftcastPvE.CanUse(out act)) return true;
                 if (AccelerationPvE.CanUse(out act, usedUp: true)) return true;
             }
-        }
+        }*/
 
         if (IsBurst && UseBurstMedicine(out act)) return true;
 
@@ -138,8 +138,8 @@ public sealed class RDM_Default : RedMageRotation
         //Grand impact usage if not interrupting melee combo
         if (!didWeJustCombo && GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: Player.HasStatus(true, StatusID.GrandImpactReady), skipCastingCheck:true, skipAoeCheck: true)) return true;
 
-        //Acceleration/Swiftcast usage on move
-        if (IsMoving && 
+        //Acceleration/Swiftcast usage on move, old method on line 61.
+        if (IsMoving && !Player.HasStatus(true, StatusID.Dualcast) &&
             //Checks for not override previous acceleration and lose grand impact
             !Player.HasStatus(true, StatusID.Acceleration) && 
             !Player.HasStatus(true, StatusID.GrandImpactReady) &&
@@ -154,7 +154,7 @@ public sealed class RDM_Default : RedMageRotation
 
          //Reprise logic
         if (IsMoving && RangedSwordplay && !didWeJustCombo &&
-            //Check to not use Reprise when player can do melee combo
+            //Check to not use Reprise when player can do melee combo, to not break it
             (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50) &&
             //Check if dualcast active
             !Player.HasStatus(true, StatusID.Dualcast) &&

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -109,8 +109,10 @@ public sealed class RDM_Default : RedMageRotation
               ActionID.EnchantedMoulinetPvE
           });
 
-        //Acceleration usage on combo with saving 1 charge for movement
-        if (!checkmelee && !Player.HasStatus(true, StatusID.Dualcast) && AccelerationPvE.CanUse(out act)) return true;
+        //Acceleration usage on rotation with saving 1 charge for movement
+        if (!checkmelee && (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50) && //i hate this.
+                            !Player.HasStatus(true, StatusID.Manafication, StatusID.Embolden, StatusID.MagickedSwordplay) &&
+                            !Player.HasStatus(true, StatusID.Dualcast) && AccelerationPvE.CanUse(out act))) return true;
     
         //Acceleration/Swiftcast usage on move
         if (IsMoving && !Player.HasStatus(true, StatusID.Dualcast) && !checkmelee &&

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -135,8 +135,7 @@ public sealed class RDM_Default : RedMageRotation
         bool didWeJustCombo = IsLastGCD([
             ActionID.ScorchPvE, ActionID.VerflarePvE, ActionID.VerholyPvE, ActionID.ZwerchhauPvE,
             ActionID.RedoublementPvE]);
-
-
+        //Grand impact usage if not interrupting melee combo
         if (!didWeJustCombo && GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: Player.HasStatus(true, StatusID.GrandImpactReady), skipCastingCheck:true, skipAoeCheck: true)) return true;
 
         //Acceleration/Swiftcast usage on move
@@ -152,7 +151,7 @@ public sealed class RDM_Default : RedMageRotation
         {
             return true;
         }
-        
+
          //Reprise logic
         if (IsMoving && RangedSwordplay && !didWeJustCombo &&
             //Check to not use Reprise when player can do melee combo

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -126,13 +126,37 @@ public sealed class RDM_Default : RedMageRotation
         if (ManaStacks > 0 && RipostePvE.CanUse(out act)) return true;
         
         if (IsMoving && RangedSwordplay && (ReprisePvE.CanUse(out act) || EnchantedReprisePvE.CanUse(out act))) return true;
+<<<<<<< Updated upstream
 
+=======
+        
+>>>>>>> Stashed changes
         return base.EmergencyGCD(out act);
     }
 
     protected override bool GeneralGCD(out IAction? act)
     {
         act = null;
+<<<<<<< Updated upstream
+=======
+
+        //Swiftcast and acceleration usage (experimental, old method on line 61)
+        //Check if player moving and dont have acceleration buff already to not override it
+        if (IsMoving && !Player.HasStatus(true, StatusID.Acceleration) &&
+        //Additional checks to NOT INTERRUPT DOUBLE/TRIPLE melee combos, ANY COMBO
+            (ManaStacks == 0 && (BlackMana < 50 || WhiteMana < 50) &&
+            !IsLastGCD(ActionID.ResolutionPvE) &&
+            //Check if player dont have GrandImpact buff
+            !Player.HasStatus(true, StatusID.GrandImpactReady) &&
+            //Fires acceleration. If player dont have acceleration at all, fires swiftcast instead
+            (AccelerationPvE.CanUse(out act, usedUp: true) || (!AccelerationPvE.CanUse(out _) && SwiftcastPvE.CanUse(out act))))) return true;
+
+        //Grand impact usage
+        if (!IsLastGCD(ActionID.ResolutionPvE) && /*<- additional melee protection, just to be sure*/
+        GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: Player.HasStatus(true, StatusID.GrandImpactReady), skipCastingCheck: true, skipAoeCheck: true)) return true;
+
+
+>>>>>>> Stashed changes
         if (ManaStacks == 3) return false;
         
         if (GrandImpactPvE.CanUse(out act)) return true;

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -44,7 +44,7 @@ public sealed class RDM_Default : RedMageRotation
     
     //When we removed emergencyGCD vercure/verraise start overwriting all logic below. Need to do something about it.
     
-    //No bugs in this section, i polished it. Extra Methods is fucked up tho, need to good look of experienced rotation dev.
+    //No bugs in this section (mostly™). Extra Methods is fucked up tho, need to good look of experienced rotation dev.
     
 {
     bool AnyoneInRange = AllHostileTargets.Any(hostile => hostile.DistanceToPlayer() <= 4);

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -126,19 +126,13 @@ public sealed class RDM_Default : RedMageRotation
         if (ManaStacks > 0 && RipostePvE.CanUse(out act)) return true;
         
         if (IsMoving && RangedSwordplay && (ReprisePvE.CanUse(out act) || EnchantedReprisePvE.CanUse(out act))) return true;
-<<<<<<< Updated upstream
-
-=======
         
->>>>>>> Stashed changes
         return base.EmergencyGCD(out act);
     }
 
     protected override bool GeneralGCD(out IAction? act)
     {
         act = null;
-<<<<<<< Updated upstream
-=======
 
         //Swiftcast and acceleration usage (experimental, old method on line 61)
         //Check if player moving and dont have acceleration buff already to not override it
@@ -155,8 +149,6 @@ public sealed class RDM_Default : RedMageRotation
         if (!IsLastGCD(ActionID.ResolutionPvE) && /*<- additional melee protection, just to be sure*/
         GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: Player.HasStatus(true, StatusID.GrandImpactReady), skipCastingCheck: true, skipAoeCheck: true)) return true;
 
-
->>>>>>> Stashed changes
         if (ManaStacks == 3) return false;
         
         if (GrandImpactPvE.CanUse(out act)) return true;

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -53,7 +53,7 @@ public sealed class RDM_Default : RedMageRotation
     
     if (CombatElapsedLess(4)) return false;
     
-    //COMMENT FOR MYSELF FROM FUTURE - WHY THE FUCK EMBOLDEN DONT WORK WITHOUT skipAoeCheck:true???
+    //COMMENT FOR MYSELF FROM FUTURE - WHY THE HELL EMBOLDEN DONT WORK WITHOUT skipAoeCheck:true???
     if (!AnyonesMeleeRule)
     {
         if (IsBurst && HasHostilesInRange && EmboldenPvE.CanUse(out act, skipAoeCheck: true)) return true;
@@ -101,7 +101,7 @@ public sealed class RDM_Default : RedMageRotation
         ActionID.EnchantedMoulinetDeuxPvE,
         ActionID.EnchantedMoulinetPvE,
         ActionID.MoulinetPvE
-        //I dont know at this point if nextGCD.IsTheSameTo even fucking working, but stil gonna left it in here.
+        //I dont know at this point if nextGCD.IsTheSameTo even working, but stil gonna left it in here.
     }) && !nextGCD.IsTheSameTo(new[]
     {
         ActionID.RipostePvE,

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -133,8 +133,8 @@ public sealed class RDM_Default : RedMageRotation
         act = null;
 
         bool didWeJustCombo = IsLastGCD([
-            ActionID.ScorchPvE, ActionID.VerflarePvE, ActionID.VerholyPvE, ActionID.ZwerchhauPvE,
-            ActionID.RedoublementPvE]);
+            ActionID.ScorchPvE, ActionID.VerflarePvE, ActionID.VerholyPvE, ActionID.EnchantedZwerchhauPvE,
+            ActionID.EnchantedRedoublementPvP, ActionID.EnchantedRipostePvE]);
         //Grand impact usage if not interrupting melee combo
         if (!didWeJustCombo && GrandImpactPvE.CanUse(out act, skipStatusProvideCheck: Player.HasStatus(true, StatusID.GrandImpactReady), skipCastingCheck:true, skipAoeCheck: true)) return true;
 

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -110,7 +110,7 @@ public sealed class RDM_Default : RedMageRotation
           });
 
         //Acceleration usage on combo with saving 1 charge for movement
-        if (!checkmelee && AccelerationPvE.CanUse(out act)) return true;
+        if (!checkmelee && !Player.HasStatus(true, StatusID.Dualcast) && AccelerationPvE.CanUse(out act)) return true;
     
         //Acceleration/Swiftcast usage on move
         if (IsMoving && !Player.HasStatus(true, StatusID.Dualcast) && !checkmelee &&

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -18,7 +18,7 @@ public sealed class RDM_Default : RedMageRotation
     public bool AnyonesMeleeRule { get; set; } = false;
 
     //Fine, ill do it myself
-    [RotationConfig(CombatType.PvE, Name = "Cast manafication outside of embolden window.")]
+    [RotationConfig(CombatType.PvE, Name = "Cast manafication outside of embolden window (use at own risk).")]
     public bool AnyoneManafication { get; set; } = false;
     #endregion
 

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -114,7 +114,7 @@ public sealed class RDM_Default : RedMageRotation
     bool ambatumelee = Player.HasStatus(true, StatusID.Manafication, StatusID.MagickedSwordplay);
 
     //Acceleration usage on rotation with saving 1 charge for movement
-    if (!checkmelee && !ambatumelee && //i hate this.
+    if (GrandImpactPvE.EnoughLevel && !checkmelee && !ambatumelee && //Check for enough level to use Grand Impact, or its pointless.
         !Player.HasStatus(true, StatusID.Manafication, StatusID.MagickedSwordplay) &&
         !Player.HasStatus(true, StatusID.Dualcast) && AccelerationPvE.CanUse(out act)) return true;
     


### PR DESCRIPTION
Fixed melee AOE, now get used properly.
Added additional config for use manafication outside of embolden window (ONLY IN MELEE).

Added additional logic to acceleration/swiftcast usage on move, they will not overwrite each other anymore.
After each acceleration grand impact will be used.

Added aditional logic to reprise usage, now rotation prioritize ANYTHING (acceleartion/swiftcast/any spells that can be instacasted) instead of reprise, also, added check if player have 50/50 mana - reprise not will be used to not break ready melee combo.