### PR TITLE
Dragood fix and optimization pass

### DIFF
--- a/BasicRotations/Melee/DRG_Default.cs
+++ b/BasicRotations/Melee/DRG_Default.cs
@@ -1,3 +1,5 @@
+using FFXIVClientStructs.FFXIV.Client.Game.Gauge;
+
 namespace DefaultRotations.Melee;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.01")]
@@ -16,12 +18,6 @@ public sealed class DRG_Default : DragoonRotation
     [RotationDesc]
     protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
     {
-        if (nextGCD.IsTheSameTo(true, FullThrustPvE, CoerthanTormentPvE)
-            || Player.HasStatus(true, StatusID.LanceCharge) && nextGCD.IsTheSameTo(false, FangAndClawPvE))
-            {
-            if (LifeSurgePvE.CanUse(out act, usedUp: true)) return true;
-        }
-
         return base.EmergencyAbility(nextGCD, out act);
     }
 
@@ -54,6 +50,13 @@ public sealed class DRG_Default : DragoonRotation
     {
         if (IsBurst && InCombat)
         {
+            if ((Player.HasStatus(true, StatusID.BattleLitany) || Player.HasStatus(true, StatusID.LanceCharge) || LOTDEndAfter(1000)) && nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE)
+            || (Player.HasStatus(true, StatusID.BattleLitany) && Player.HasStatus(true, StatusID.LanceCharge) && LOTDEndAfter(1000) && nextGCD.IsTheSameTo(true, ChaoticSpringPvE, LanceBarragePvE, WheelingThrustPvE, FangAndClawPvE))
+            || (nextGCD.IsTheSameTo(true, HeavensThrustPvE, DrakesbanePvE) && (LanceChargePvE.IsInCooldown || BattleLitanyPvE.IsInCooldown)))
+            {
+                if (LifeSurgePvE.CanUse(out act, usedUp: true)) return true;
+            }
+
             if (LanceChargePvE.CanUse(out act)) return true;
 
             if (BattleLitanyPvE.CanUse(out act)) return true;
@@ -64,28 +67,31 @@ public sealed class DRG_Default : DragoonRotation
 
     protected override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
-        if (StarcrossPvE.CanUse(out act)) return true;
-        if (NastrondPvE.CanUse(out act)) return true;
-        if (StardiverPvE.CanUse(out act)) return true;
-
-        if (HighJumpPvE.CanUse(out act)) return true;
-        if (JumpPvE.CanUse(out act)) return true;
-
-
         if (Player.HasStatus(true, StatusID.LanceCharge) && LanceChargePvE.Cooldown.ElapsedOneChargeAfterGCD(3))
         {
             if (GeirskogulPvE.CanUse(out act)) return true;
         }
-
-        if (MirageDivePvE.CanUse(out act)) return true;
 
         if (Player.HasStatus(true, StatusID.LanceCharge) && LanceChargePvE.Cooldown.ElapsedOneChargeAfterGCD(3))
         {
             if (DragonfireDivePvE.CanUse(out act)) return true;
         }
 
-        if (WyrmwindThrustPvE.CanUse(out act)) return true;
+        if ((Player.HasStatus(true, StatusID.BattleLitany) || Player.HasStatus(true, StatusID.LanceCharge) || LOTDEndAfter(1000))
+            || nextGCD.IsTheSameTo(true, RaidenThrustPvE, DraconianFuryPvE))
+        {
+            if (WyrmwindThrustPvE.CanUse(out act, usedUp: true)) return true;
+        }
+
+        if (HighJumpPvE.CanUse(out act)) return true;
+        if (StardiverPvE.CanUse(out act)) return true;
+
+
+        if (MirageDivePvE.CanUse(out act)) return true;
+        if (NastrondPvE.CanUse(out act)) return true;
+        if (StarcrossPvE.CanUse(out act)) return true;
         if (RiseOfTheDragonPvE.CanUse(out act)) return true;
+        if (HighJumpPvE.CanUse(out act)) return true;
 
         return base.AttackAbility(nextGCD, out act);
     }
@@ -100,25 +106,25 @@ public sealed class DRG_Default : DragoonRotation
         if (SonicThrustPvE.CanUse(out act)) return true;
         if (DoomSpikePvE.CanUse(out act, skipComboCheck: doomSpikeRightNow)) return true;
 
-
-        if (DrakesbanePvE.CanUse(out act)) return true;
-        if (WheelingThrustPvE.CanUse(out act)) return true;
-        if (FangAndClawPvE.CanUse(out act)) return true;
-
-
-        if (FullThrustPvE.CanUse(out act)) return true;
-        if (ChaosThrustPvE.CanUse(out act)) return true;
-
         if (Player.WillStatusEndGCD(5, 0, true, StatusID.PowerSurge_2720))
         {
             if (DisembowelPvE.CanUse(out act)) return true;
         }
 
-        if (VorpalThrustPvE.CanUse(out act)) return true;
-        if (TrueThrustPvE.CanUse(out act)) return true;
-        if (RaidenThrustPvE.CanUse(out act)) return true;
+        if (DrakesbanePvE.CanUse(out act)) return true;
+
+        if (FangAndClawPvE.CanUse(out act)) return true;
+        if (WheelingThrustPvE.CanUse(out act)) return true;
+
+        if (HeavensThrustPvE.CanUse(out act)) return true;
+        if (ChaoticSpringPvE.CanUse(out act)) return true;
+
         if (LanceBarragePvE.CanUse(out act)) return true;
         if (SpiralBlowPvE.CanUse(out act)) return true;
+
+        if (RaidenThrustPvE.CanUse(out act)) return true;
+        if (TrueThrustPvE.CanUse(out act)) return true;
+
         if (PiercingTalonPvE.CanUse(out act)) return true;
 
         return base.GeneralGCD(out act);


### PR DESCRIPTION
Dragoon GCD ordered correctly, checks for Wyrmwind to be used when under damage buff or before overcap, Lifesurge check to ensure good damage potency