### PR TITLE
MNK full auto

### DIFF
--- a/BasicRotations/Melee/MNK_Default.cs
+++ b/BasicRotations/Melee/MNK_Default.cs
@@ -23,7 +23,7 @@ public sealed class MNK_Default : MonkRotation
         // gap closer at the end of countdown
         if (remainTime <= 0.5 && ThunderclapPvE.CanUse(out var act)) return act; // need to face target to trigger
         // true north before pull
-        if (remainTime <= 4 && TrueNorthPvE.CanUse(out act)) return act;
+        if (remainTime <= 2 && TrueNorthPvE.CanUse(out act)) return act;
         // turn on 5 chakra at -5 prepull 
         if (remainTime <= 5 && Chakra < 5 && ForbiddenMeditationPvE.CanUse(out act)) return act;
         // formShift to prep opening
@@ -38,7 +38,7 @@ public sealed class MNK_Default : MonkRotation
     {
         // PerfectBalancePvE after first gcd + TheForbiddenChakraPvE after second gcd
         // fail to weave both after first gcd - rsr doesn't have enough time to react to both spells
-        // you pot -2s prepull or after 2nd gcd!!! 
+        // you pot -2s (real world -3s) prepull or after 2nd gcd!!! 
         // there is a small chance PB is not pressed in time if put in AttackAbility
         // start the fight 8 yarms away from boss for double weaving
         // 'The form shift and meditation prepull are implied. Prepull pot should win out, but choosing to press it in the first few weave slots shouldn¡¯t result in more than a single digit loss'

--- a/BasicRotations/Melee/MNK_Default.cs
+++ b/BasicRotations/Melee/MNK_Default.cs
@@ -6,23 +6,28 @@ namespace DefaultRotations.Melee;
 
 public sealed class MNK_Default : MonkRotation
 {
-
     #region Config Options
     [RotationConfig(CombatType.PvE, Name = "Use Form Shift")]
     public bool AutoFormShift { get; set; } = true;
+
+    [RotationConfig(CombatType.PvE, Name = "Auto Use Perfect Balance (single target full auto mode, turn me off if you want total control of PB)")]
+    public bool AutoPB_Boss { get; set; } = true;
+
+    [RotationConfig(CombatType.PvE, Name = "Auto Use Perfect Balance (aoe aggressive PB dump, turn me off if you don't want to waste PB in boss fight)")]
+    public bool AutoPB_AOE { get; set; } = true;
     #endregion
 
     #region Countdown Logic
     protected override IAction? CountDownAction(float remainTime)
     {
-        if (remainTime < 0.2)
-        {
-            if (ThunderclapPvE.CanUse(out var act)) return act; // Gap closer at the end of countdown
-        }
-        if (remainTime < 15)
-        {
-            if (FormShiftPvE.CanUse(out var act)) return act; // FormShift to prep opening
-        }
+        // gap closer at the end of countdown
+        if (remainTime <= 0.5 && ThunderclapPvE.CanUse(out var act)) return act; // need to face target to trigger
+        // true north before pull
+        if (remainTime <= 4 && TrueNorthPvE.CanUse(out act)) return act;
+        // turn on 5 chakra at -5 prepull 
+        if (remainTime <= 5 && Chakra < 5 && ForbiddenMeditationPvE.CanUse(out act)) return act;
+        // formShift to prep opening
+        if (remainTime < 15 && FormShiftPvE.CanUse(out act)) return act;
 
         return base.CountDownAction(remainTime);
     }
@@ -31,38 +36,78 @@ public sealed class MNK_Default : MonkRotation
     #region oGCD Logic
     protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
     {
-        if (InCombat)
-        {
-            if (UseBurstMedicine(out act)) return true;
-            if (IsBurst && !CombatElapsedLessGCD(2) && RiddleOfFirePvE.CanUse(out act)) return true;
-        }
+        // PerfectBalancePvE after first gcd + TheForbiddenChakraPvE after second gcd
+        // fail to weave both after first gcd - rsr doesn't have enough time to react to both spells
+        // you pot -2s prepull or after 2nd gcd!!! 
+        // there is a small chance PB is not pressed in time if put in AttackAbility
+        // start the fight 8 yarms away from boss for double weaving
+        // 'The form shift and meditation prepull are implied. Prepull pot should win out, but choosing to press it in the first few weave slots shouldn¡¯t result in more than a single digit loss'
+        // 'there may be a delay before it can be used. Pushing it to the 2nd weave slot should avoid this.'
+        if (AutoPB_Boss && InCombat && CombatElapsedLess(3) && PerfectBalancePvE.CanUse(out act, usedUp: true)) return true;
+        //if (CombatElapsedLessGCD(1) && TheForbiddenChakraPvE.CanUse(out act)) return true; // if it weaves one day in the future...
+
+        // need this to connect the first three buffs
+        if (IsLastAbility(true, BrotherhoodPvE) && RiddleOfFirePvE.CanUse(out act)) return true; // Riddle Of Fire
+
         return base.EmergencyAbility(nextGCD, out act);
     }
 
     protected override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
-        act = null;
-
-        if (CombatElapsedLessGCD(3)) return false; // Prevents the use of abilities if 3 GCDs have not been used
-
-        if (EarthsReplyPvE.CanUse(out act, skipAoeCheck: true) && (Player.CurrentHp < Player.MaxHp)) return true; // Earths Reply
-
-        if (BeastChakras.Contains(BeastChakra.NONE) && Player.HasStatus(true, StatusID.RaptorForm)
-            && (!RiddleOfFirePvE.EnoughLevel || Player.HasStatus(false, StatusID.RiddleOfFire) && !Player.WillStatusEndGCD(3, 0, false, StatusID.RiddleOfFire)
-            || RiddleOfFirePvE.Cooldown.WillHaveOneChargeGCD(1) && (PerfectBalancePvE.Cooldown.ElapsedAfter(60) || !PerfectBalancePvE.Cooldown.IsCoolingDown)))
+        // you need to position yourself in the centre of the mobs if they are large, that range is only 3 yarms
+        if (AutoPB_AOE && NumberOfHostilesInRange >= 2)
         {
-            if (PerfectBalancePvE.CanUse(out act, usedUp: true)) return true; // Perfect Balance
+            if (PerfectBalancePvE.CanUse(out act, usedUp: true)) return true;
         }
 
-        if (BrotherhoodPvE.CanUse(out act, skipAoeCheck: true)) return true; // Brotherhood
-        if (EnlightenmentPvE.CanUse(out act)) return true; // Enlightment
-        if (HowlingFistPvE.CanUse(out act)) return true; // Howling Fist
-        if (SteelPeakPvE.CanUse(out act)) return true; // Steel Peak
-        
-        //if (HowlingFistPvE.CanUse(out act, skipAoeCheck: true)) return true; // Howling Fist AOE
+        // opener 2nd burst
+        if (AutoPB_Boss
+            && Player.HasStatus(true, StatusID.RiddleOfFire) && Player.HasStatus(true, StatusID.Brotherhood)
+            && IsLastGCD(true, DragonKickPvE, LeapingOpoPvE, BootshinePvE) // PB must follow an Opo
+            && !Player.HasStatus(true, StatusID.FormlessFist) && !Player.HasStatus(true, StatusID.FiresRumination) && !Player.HasStatus(true, StatusID.WindsRumination))
+        {
+            if (PerfectBalancePvE.CanUse(out act, usedUp: true)) return true;
+        }
 
-        if (RiddleOfWindPvE.CanUse(out act)) return true; // Riddle Of Wind
+        // odd min burst
+        if (AutoPB_Boss
+            && Player.HasStatus(true, StatusID.RiddleOfFire)
+            && !PerfectBalancePvE.Cooldown.JustUsedAfter(20)
+            && IsLastGCD(true, DragonKickPvE, LeapingOpoPvE, BootshinePvE)) // PB must follow an Opo 
+        {
+            if (PerfectBalancePvE.CanUse(out act, usedUp: true)) return true;
+        }
 
+        // even min burst
+        if (AutoPB_Boss
+            && !Player.HasStatus(true, StatusID.RiddleOfFire)
+            && RiddleOfFirePvE.Cooldown.WillHaveOneChargeGCD(3) && BrotherhoodPvE.Cooldown.WillHaveOneCharge(3)
+            && IsLastGCD(true, DragonKickPvE, LeapingOpoPvE, BootshinePvE)) // PB must follow an Opo 
+        {
+            if (PerfectBalancePvE.CanUse(out act, usedUp: true)) return true;
+        }
+
+        // 'TFC is used in the first weave slot to avoid any chakra overcap from the following gcds.'
+        // dump 5 stacks of chakara 
+        if (NumberOfHostilesInRange >= 2)
+        {
+            if (EnlightenmentPvE.CanUse(out act, skipAoeCheck: true)) return true; // Enlightment
+            if (HowlingFistPvE.CanUse(out act, skipAoeCheck: true)) return true; // Howling Fist
+        }
+        else
+            if (TheForbiddenChakraPvE.CanUse(out act)) return true;
+
+        // use bh when bh and rof are ready (opener) or ask bh to wait for rof's cd to be close and then use bh
+        if (!CombatElapsedLessGCD(2)
+            && ((BrotherhoodPvE.IsInCooldown && RiddleOfFirePvE.IsInCooldown) || Math.Abs(BrotherhoodPvE.Cooldown.CoolDownGroup - RiddleOfFirePvE.Cooldown.CoolDownGroup) < 3)
+            && BrotherhoodPvE.CanUse(out act, skipAoeCheck: true)) return true;
+
+        // rof needs to be used on cd or after x gcd in opener
+        if (!CombatElapsedLessGCD(3) && RiddleOfFirePvE.CanUse(out act)) return true; // Riddle Of Fire
+        // 'Use on cooldown, unless you know your killtime. You should aim to get as many casts of RoW as you can, and then shift those usages to align with burst as much as possible without losing a use.'
+        if (!CombatElapsedLessGCD(3) && RiddleOfWindPvE.CanUse(out act)) return true; // Riddle Of Wind
+
+        // what's this? check later
         if (MergedStatus.HasFlag(AutoStatus.MoveForward) && MoveForwardAbility(nextGCD, out act)) return true;
 
         return base.AttackAbility(nextGCD, out act);
@@ -70,163 +115,93 @@ public sealed class MNK_Default : MonkRotation
     #endregion
 
     #region GCD Logic
+    // 'More opos in the fight is better than... in lunar PBs'
     private bool OpoOpoForm(out IAction? act)
     {
-        if (ArmOfTheDestroyerPvE.CanUse(out act)) return true; // Arm Of The Destoryer
+        if (ArmOfTheDestroyerPvE.CanUse(out act)) return true; // Arm Of The Destoryer - aoe
         if (LeapingOpoPvE.CanUse(out act)) return true; // Leaping Opo
         if (DragonKickPvE.CanUse(out act)) return true; // Dragon Kick
-        if (BootshinePvE.CanUse(out act)) return true; //Bootshine
+        if (BootshinePvE.CanUse(out act)) return true; //Bootshine - low level
         return false;
     }
 
-    private bool UseLunarPerfectBalance => (HasSolar || Player.HasStatus(false, StatusID.PerfectBalance))
-        && (!Player.WillStatusEndGCD(0, 0, false, StatusID.RiddleOfFire) || Player.HasStatus(false, StatusID.RiddleOfFire) || RiddleOfFirePvE.Cooldown.WillHaveOneChargeGCD(2)) && PerfectBalancePvE.Cooldown.WillHaveOneChargeGCD(3);
-
     private bool RaptorForm(out IAction? act)
     {
-        if (FourpointFuryPvE.CanUse(out act)) return true; //Fourpoint Fury
-        /*if ((Player.WillStatusEndGCD(3, 0, true, StatusID.DisciplinedFist)
-            || Player.WillStatusEndGCD(7, 0, true, StatusID.DisciplinedFist)
-            && UseLunarPerfectBalance) && TwinSnakesPvE.CanUse(out act)) return true; //Twin Snakes*/
+        if (FourpointFuryPvE.CanUse(out act)) return true; //Fourpoint Fury - aoe
         if (RisingRaptorPvE.CanUse(out act)) return true; //Rising Raptor
         if (TwinSnakesPvE.CanUse(out act)) return true; //Twin Snakes
-        if (TrueStrikePvE.CanUse(out act)) return true; //True Strike
+        if (TrueStrikePvE.CanUse(out act)) return true; //True Strike - low level
         return false;
     }
 
     private bool CoerlForm(out IAction? act)
     {
-        if (RockbreakerPvE.CanUse(out act)) return true; // Rockbreaker
-        //if (UseLunarPerfectBalance && DemolishPvE.CanUse(out act, skipStatusProvideCheck: true)) return true;
-        //&& (DemolishPvE.Target.Target?.WillStatusEndGCD(7, 0, true, StatusID.Demolish) ?? false)) return true;
+        if (RockbreakerPvE.CanUse(out act)) return true; // Rockbreaker - aoe
         if (PouncingCoeurlPvE.CanUse(out act)) return true; // Pouncing Coeurl
         if (DemolishPvE.CanUse(out act)) return true; // Demolish
-        if (SnapPunchPvE.CanUse(out act)) return true; // Snap Punch
+        if (SnapPunchPvE.CanUse(out act)) return true; // Snap Punch - low level
         return false;
     }
 
     protected override bool GeneralGCD(out IAction? act)
     {
-        if (WindsReplyPvE.CanUse(out act, skipAoeCheck: true)) return true; // Winds Reply
-        if (FiresReplyPvE.CanUse(out act, skipAoeCheck: true)) return true; // Fires Reply
-        if (Player.HasStatus(true, StatusID.MeditativeBrotherhood) && Chakra >= 5 && TheForbiddenChakraPvE.CanUse(out act)) return true;
-
-        if (PerfectBalanceActions(out act)) return true;
-
-        if (Player.HasStatus(true, StatusID.CoeurlForm))
+        // bullet proofed finisher - use when during burst
+        // or if burst was missed, and next burst is not arriving in time, use it better than waste it, otherwise, hold it for next rof
+        if (!BeastChakras.Contains(BeastChakra.NONE) && (Player.HasStatus(true, StatusID.RiddleOfFire) || RiddleOfFirePvE.Cooldown.JustUsedAfter(42)))
         {
-            if (CoerlForm(out act)) return true; // Use Coeurl Form GCDs if in Coeurl Form
+            // for some reason phantom doesn't count as a variation of masterful like the others
+            if (PhantomRushPvE.CanUse(out act, skipAoeCheck: true)) return true;
+            if (TornadoKickPvE.CanUse(out act, skipAoeCheck: true)) return true;
+            if (CelestialRevolutionPvE.CanUse(out act, skipAoeCheck: true)) return true; // shouldn't need this but who know what button the user may press
+            if (MasterfulBlitzPvE.CanUse(out act, skipAoeCheck: true)) return true;
         }
 
-        if (Player.HasStatus(true, StatusID.RiddleOfFire)
-            && !RiddleOfFirePvE.Cooldown.ElapsedAfterGCD(2) && (PerfectBalancePvE.Cooldown.ElapsedAfter(60) || !PerfectBalancePvE.Cooldown.IsCoolingDown))
+        // 'Because Fire¡¯s Reply grants formless, we have an imposed restriction that we prefer not to use it while under PB, or if we have a formless already.' + 'Cast Fire's Reply after an opo gcd'
+        // need to test and see if IsLastGCD(false, ...) is better
+        if ((!Player.HasStatus(true, StatusID.PerfectBalance) && !Player.HasStatus(true, StatusID.FormlessFist) && IsLastGCD(true, DragonKickPvE, LeapingOpoPvE, BootshinePvE) || Player.WillStatusEnd(5, true, StatusID.FiresRumination)) && FiresReplyPvE.CanUse(out act, skipAoeCheck: true)) return true; // Fires Reply
+        // 'Cast Wind's Reply literally anywhere in the window'
+        if (!Player.HasStatus(true, StatusID.PerfectBalance) && WindsReplyPvE.CanUse(out act, skipAoeCheck: true)) return true; // Winds Reply
+
+        // Opo needs to follow each PB
+        // 'This means ¡°bookending¡± any PB usage with opos and spending formless on opos.'
+        if (Player.HasStatus(true, StatusID.FormlessFist) && OpoOpoForm(out act)) return true;
+        //if (Player.StatusStack(true, StatusID.PerfectBalance) == 3 && OpoOpoForm(out act)) return true;
+
+        if (Player.HasStatus(true, StatusID.PerfectBalance) && !HasSolar)
         {
+            // SolarNadi - fill the missing one - this order is needed for opener
+            if (!BeastChakras.Contains(BeastChakra.RAPTOR) && RaptorForm(out act)) return true;
+            if (!BeastChakras.Contains(BeastChakra.COEURL) && CoerlForm(out act)) return true;
+            if (!BeastChakras.Contains(BeastChakra.OPOOPO) && OpoOpoForm(out act)) return true;
+        }
+
+        if (Player.HasStatus(true, StatusID.PerfectBalance) && HasSolar)
+        {
+            // 'we still want to prioritize pressing as many opo gcds as possible'
+            // LunarNadi
             if (OpoOpoForm(out act)) return true;
         }
 
-        if (Player.HasStatus(true, StatusID.RaptorForm))
-        {
-            if (RaptorForm(out act)) return true; // Use Raptor Form GCDs if in Raptor Form
-        }
+        // whatever you have, press it from left to right
+        if (CoerlForm(out act)) return true;
+        if (RaptorForm(out act)) return true;
+        if (OpoOpoForm(out act)) return true;
 
-        if (OpoOpoForm(out act)) return true; // Fallback to Use OpoOpo Form GCDs 
-
+        // out of range or nothing to do, recharge chakra first
         if (Chakra < 5 && (ForbiddenMeditationPvE.CanUse(out act) || SteeledMeditationPvE.CanUse(out act))) return true;
 
-        if (AutoFormShift && FormShiftPvE.CanUse(out act)) return true; // Form Shift GCD use
+        // out of range or nothing to do, refresh buff second, but dont keep refreshing or it draws too much attention
+        if (AutoFormShift && !Player.HasStatus(true, StatusID.PerfectBalance) && !Player.HasStatus(true, StatusID.FormlessFist) && FormShiftPvE.CanUse(out act)) return true; // Form Shift GCD use
+
+        // i'm clever and i can do kame hame ha, so i won't stand still and keep refreshing form shift
+        if (EnlightenmentPvE.CanUse(out act, skipAoeCheck: true)) return true; // Enlightment
+        if (HowlingFistPvE.CanUse(out act, skipAoeCheck: true)) return true; // Howling Fist
 
         return base.GeneralGCD(out act);
-    }
-
-    private bool PerfectBalanceActions(out IAction? act) // Controls actions during Perfect Balance buff
-    {
-        if (!BeastChakras.Contains(BeastChakra.NONE))
-        {
-            if (HasSolar && HasLunar)
-            {
-                if (PhantomRushPvE.CanUse(out act, skipAoeCheck: true)) return true;
-                if (TornadoKickPvE.CanUse(out act, skipAoeCheck: true)) return true;
-            }
-            if (BeastChakras.Contains(BeastChakra.RAPTOR))
-            {
-                if (RisingPhoenixPvE.CanUse(out act, skipAoeCheck: true)) return true;
-                if (FlintStrikePvE.CanUse(out act, skipAoeCheck: true)) return true;
-            }
-            else
-            {
-                if (ElixirBurstPvE.CanUse(out act, skipAoeCheck: true)) return true;
-                if (ElixirFieldPvE.CanUse(out act, skipAoeCheck: true)) return true;
-            }
-        }
-        else if (Player.HasStatus(true, StatusID.PerfectBalance) && (ElixirBurstPvE.EnoughLevel || ElixirFieldPvE.EnoughLevel))
-        {
-            //Sometimes, no choice
-            if (HasSolar || BeastChakras.Count(c => c == BeastChakra.OPOOPO) > 1)
-            {
-                if (LunarNadi(out act)) return true;
-            }
-            else if (BeastChakras.Contains(BeastChakra.COEURL) || BeastChakras.Contains(BeastChakra.RAPTOR))
-            {
-                if (SolarNadi(out act)) return true;
-            }
-
-            //Add Solar Nadi if Lunar Nadi is present.
-            if (HasLunar)
-            {
-                if (SolarNadi(out act)) return true;
-            }
-            if (LunarNadi(out act)) return true;
-        }
-
-        act = null;
-        return false;
-    }
-
-    bool LunarNadi(out IAction? act)
-    {
-        if (OpoOpoForm(out act)) return true;
-        return false;
-    }
-
-    bool SolarNadi(out IAction? act)
-    {
-        //Emergency usage of status.
-        /*if (!BeastChakras.Contains(BeastChakra.RAPTOR)
-            && HasLunar
-            && Player.WillStatusEndGCD(1, 0, true, StatusID.DisciplinedFist))
-        {
-            if (RaptorForm(out act)) return true;
-        }
-        if (!BeastChakras.Contains(BeastChakra.COEURL)
-            && (HostileTarget?.WillStatusEndGCD(1, 0, true, StatusID.Demolish) ?? false))
-        {
-            if (CoerlForm(out act)) return true;
-        }*/
-
-        if (!BeastChakras.Contains(BeastChakra.OPOOPO))
-        {
-            if (OpoOpoForm(out act)) return true;
-        }
-        if (HasLunar && !BeastChakras.Contains(BeastChakra.RAPTOR))
-        {
-            if (RaptorForm(out act)) return true;
-        }
-        if (!BeastChakras.Contains(BeastChakra.COEURL))
-        {
-            if (CoerlForm(out act)) return true;
-        }
-        if (!BeastChakras.Contains(BeastChakra.RAPTOR))
-        {
-            if (RaptorForm(out act)) return true;
-        }
-
-        return CoerlForm(out act);
     }
     #endregion
 
     #region Extra Methods
-
-    private static bool NoForm => ((!Player.HasStatus(false, StatusID.OpoopoForm) && !Player.HasStatus(false, StatusID.RaptorForm) && !Player.HasStatus(false, StatusID.CoeurlForm)) || Player.HasStatus(true, StatusID.FormlessFist) || Player.HasStatus(true, StatusID.PerfectBalance));
 
     #endregion
 }


### PR DESCRIPTION
MNK has been fully updated to run automatically all the way with a DK opening and restrictively ordered rotation. 
Known issue: If you die during the fight, a lot of cooldowns won't connect as they were designed to. Feel free to weave PB, BH etc by yourself. 
It's been tested on level 100 dummy, ex 1 (85 parse) and ex 2 (79 parse). Note: I don't have week 1-2 normal raid tokens for MNK and I'm using SAM-compatible gear. It's also been tested in dungeons (AOE only with duty support, not full run) on level 100, 91, 90, 81, 80 and 59.
Additional features: Added two user options - PB logics can be turned on (default) or off per user preference. No more endless form shifting etc.