### PR TITLE
NIN - Removing Huton from Prepull

### DIFF
--- a/BasicRotations/Melee/NIN_Default.cs
+++ b/BasicRotations/Melee/NIN_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Melee;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.01")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.05")]
 [SourceCode(Path = "main/DefaultRotations/Melee/NIN_Default.cs")]
 [Api(3)]
 public sealed class NIN_Default : NinjaRotation
@@ -19,11 +19,8 @@ public sealed class NIN_Default : NinjaRotation
     // Logic to determine the action to take during the countdown phase before combat starts.
     protected override IAction? CountDownAction(float remainTime)
     {
-
-        // Clears ninjutsu setup if countdown is more than 10 seconds or if Huton is the aim but shouldn't be.
-        if (remainTime > 10) ClearNinjutsu();
-        var realInHuton = IsLastAction(false, HutonPvE);
-        if (realInHuton && _ninActionAim == HutonPvE) ClearNinjutsu();
+        // Clears ninjutsu setup if countdown is more than 6 seconds or if Suiton is the aim but shouldn't be.
+        if (remainTime > 6) ClearNinjutsu();
 
         // Decision-making for ninjutsu actions based on remaining time until combat starts.
         if (DoNinjutsu(out var act))
@@ -36,7 +33,7 @@ public sealed class NIN_Default : NinjaRotation
         {
             SetNinjutsu(SuitonPvE);
         }
-        else if (remainTime < 10)
+        else if (remainTime < 6)
         {
             // If within 10 seconds to start, consider using Hide or setting up Huton.
             if (_ninActionAim == null && TenPvE.Cooldown.IsCoolingDown && HidePvE.CanUse(out act)) return act;


### PR DESCRIPTION
Huton is no longer required in the prepull since it's usage has changed to an attack. This would cause very early pulls