### PR TITLE
Reign of Beasts combo not firing due to AoE check requirement.

### DIFF
--- a/BasicRotations/RebornRotations.csproj
+++ b/BasicRotations/RebornRotations.csproj
@@ -9,7 +9,7 @@
     <None Remove="Duty\PVPRotations\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.4" />
+    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.5" />
   </ItemGroup>
   <ItemGroup>
 	  <Reference Include="Dalamud">

--- a/BasicRotations/Tank/GNB_Default.cs
+++ b/BasicRotations/Tank/GNB_Default.cs
@@ -101,9 +101,9 @@ public sealed class GNB_Default : GunbreakerRotation
 
         if (Player.HasStatus(true, StatusID.NoMercy) && BloodfestPvE.CanUse(out act)) return true;
 
-        if (IsLastGCD(false, NobleBloodPvE) && LionHeartPvE.CanUse(out act, skipComboCheck: true)) return true;
-        if (IsLastGCD(false, ReignOfBeastsPvE) && NobleBloodPvE.CanUse(out act, skipComboCheck: true)) return true;
-        if (IsLastAction(false, EyeGougePvE) && ReignOfBeastsPvE.CanUse(out act)) return true;
+        if (IsLastGCD(false, NobleBloodPvE) && LionHeartPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true)) return true;
+        if (IsLastGCD(false, ReignOfBeastsPvE) && NobleBloodPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true)) return true;
+        if (IsLastAction(false, EyeGougePvE) && ReignOfBeastsPvE.CanUse(out act, skipAoeCheck: true)) return true;
 
         if (Player.HasStatus(true, StatusID.NoMercy) && SonicBreakPvE.CanUse(out act)) return true;
         

--- a/BasicRotations/Tank/GNB_Default.cs
+++ b/BasicRotations/Tank/GNB_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Tank;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.00")]
+[Rotation("Default_CarnegieL_Fix", CombatType.PvE, GameVersion = "7.00")]
 [SourceCode(Path = "main/DefaultRotations/Tank/GNB_Default.cs")]
 [Api(3)]
 public sealed class GNB_Default : GunbreakerRotation
@@ -101,8 +101,8 @@ public sealed class GNB_Default : GunbreakerRotation
 
         if (Player.HasStatus(true, StatusID.NoMercy) && BloodfestPvE.CanUse(out act)) return true;
 
-        if (IsLastGCD(false, NobleBloodPvE) && LionHeartPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true)) return true;
-        if (IsLastGCD(false, ReignOfBeastsPvE) && NobleBloodPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true)) return true;
+        if (IsLastGCD(false, NobleBloodPvE) && LionHeartPvE.CanUse(out act, skipComboCheck: true)) return true;
+        if (IsLastGCD(false, ReignOfBeastsPvE) && NobleBloodPvE.CanUse(out act, skipComboCheck: true)) return true;
         if (IsLastAction(false, EyeGougePvE) && ReignOfBeastsPvE.CanUse(out act, skipAoeCheck: true)) return true;
 
         if (Player.HasStatus(true, StatusID.NoMercy) && SonicBreakPvE.CanUse(out act)) return true;


### PR DESCRIPTION
During runtime, Reign of Beasts was not firing due to AoE check. From my understanding, you don't want to only use Reign of Beasts of AoE.