### PR TITLE
PCT, RDM, DRG, VPR, and BRD fixes

### DIFF
--- a/BasicRotations/Magical/PCT_Default.cs
+++ b/BasicRotations/Magical/PCT_Default.cs
@@ -66,57 +66,75 @@ public sealed class PCT_Default : PictomancerRotation
 	}
 	#endregion
 
-	#region Emergency Logic
-	// Determines emergency actions to take based on the next planned GCD action.
-	protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
-	{
-		if (InCombat)
-		{
-			switch (MotifSwiftCast)
-			{
-			case MotifSwift.CreatureMotif:
-				if (nextGCD == PomMotifPvE || nextGCD == WingMotifPvE || nextGCD == MawMotifPvE || nextGCD == ClawMotifPvE)
-				{
-					if (SwiftcastPvE.CanUse(out act)) return true;
-				}
-				break;
-			case MotifSwift.WeaponMotif:
-				if (nextGCD == HammerMotifPvE)
-				{
-					if (SwiftcastPvE.CanUse(out act)) return true;
-				}
-				break;
-			case MotifSwift.LandscapeMotif:
-				if (nextGCD == StarrySkyMotifPvE)
-				{
-					if (SwiftcastPvE.CanUse(out act)) return true;
-				}
-				break;
-			case MotifSwift.AllMotif:
-				if (nextGCD == PomMotifPvE || nextGCD == WingMotifPvE || nextGCD == MawMotifPvE || nextGCD == ClawMotifPvE)
-				{
-					if (SwiftcastPvE.CanUse(out act)) return true;
-				}else
-				if (nextGCD == HammerMotifPvE)
-				{
-					if (SwiftcastPvE.CanUse(out act)) return true;
-				}else
-				if (nextGCD == StarrySkyMotifPvE)
-				{
-					if (SwiftcastPvE.CanUse(out act)) return true;
-				}
-				break;
-			case MotifSwift.NoMotif:
-				break;
-			}
-		}
-		
-		return base.EmergencyAbility(nextGCD, out act);
-	}
-	#endregion
+    #region Additional oGCD Logic
 
-	#region oGCD Logic
-	protected override bool AttackAbility(IAction nextGCD, out IAction? act)
+    protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
+    {
+        if (InCombat)
+        {
+            switch (MotifSwiftCast)
+            {
+                case MotifSwift.CreatureMotif:
+                    if (nextGCD == PomMotifPvE || nextGCD == WingMotifPvE || nextGCD == MawMotifPvE || nextGCD == ClawMotifPvE)
+                    {
+                        if (SwiftcastPvE.CanUse(out act)) return true;
+                    }
+                    break;
+                case MotifSwift.WeaponMotif:
+                    if (nextGCD == HammerMotifPvE)
+                    {
+                        if (SwiftcastPvE.CanUse(out act)) return true;
+                    }
+                    break;
+                case MotifSwift.LandscapeMotif:
+                    if (nextGCD == StarrySkyMotifPvE)
+                    {
+                        if (SwiftcastPvE.CanUse(out act)) return true;
+                    }
+                    break;
+                case MotifSwift.AllMotif:
+                    if (nextGCD == PomMotifPvE || nextGCD == WingMotifPvE || nextGCD == MawMotifPvE || nextGCD == ClawMotifPvE)
+                    {
+                        if (SwiftcastPvE.CanUse(out act)) return true;
+                    }
+                    else
+                    if (nextGCD == HammerMotifPvE)
+                    {
+                        if (SwiftcastPvE.CanUse(out act)) return true;
+                    }
+                    else
+                    if (nextGCD == StarrySkyMotifPvE)
+                    {
+                        if (SwiftcastPvE.CanUse(out act)) return true;
+                    }
+                    break;
+                case MotifSwift.NoMotif:
+                    break;
+            }
+        }
+
+        return base.EmergencyAbility(nextGCD, out act);
+    }
+
+    [RotationDesc(ActionID.SmudgePvE)]
+    protected override bool MoveForwardAbility(IAction nextGCD, out IAction? act)
+    {
+        if (SmudgePvE.CanUse(out act)) return true;
+        return base.AttackAbility(nextGCD, out act);
+    }
+
+    [RotationDesc(ActionID.AddlePvE, ActionID.TemperaCoatPvE, ActionID.TemperaGrassaPvE)]
+    protected sealed override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
+    {
+        if (AddlePvE.CanUse(out act)) return true;
+        if (TemperaCoatPvE.CanUse(out act)) return true;
+        if (TemperaGrassaPvE.CanUse(out act)) return true;
+        return base.DefenseAreaAbility(nextGCD, out act);
+    }
+    #endregion
+
+    #region oGCD Logic
+    protected override bool AttackAbility(IAction nextGCD, out IAction? act)
 	{
 		if (Player.HasStatus(true, StatusID.StarryMuse))
 		{
@@ -147,14 +165,6 @@ public sealed class PCT_Default : PictomancerRotation
 		}
 
 		return base.AttackAbility(nextGCD, out act);
-	}
-
-	protected override bool MoveForwardAbility(IAction nextGCD, out IAction? act)
-	{
-		act = null;
-
-
-		return base.MoveForwardAbility(nextGCD, out act);
 	}
 	#endregion
 

--- a/BasicRotations/Magical/RDM_Default.cs
+++ b/BasicRotations/Magical/RDM_Default.cs
@@ -2,7 +2,7 @@ using FFXIVClientStructs.FFXIV.Client.Game;
 
 namespace DefaultRotations.Magical;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.00")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.05")]
 [SourceCode(Path = "main/DefaultRotations/Magical/RDM_Default.cs")]
 [Api(3)]
 public sealed class RDM_Default : RedMageRotation
@@ -11,8 +11,8 @@ public sealed class RDM_Default : RedMageRotation
     private static BaseAction VerthunderStartUp { get; } = new BaseAction(ActionID.VerthunderPvE, false);
 
     [RotationConfig(CombatType.PvE, Name = "Use Vercure for Dualcast when out of combat.")]
-    public bool UseVercure { get; set; }
-    
+    public bool UseVercure { get; set; } = false;
+
     [RotationConfig(CombatType.PvE, Name = "Cast Reprise when moving with no instacast.")]
     public bool RangedSwordplay { get; set; } = false;
     

--- a/BasicRotations/Melee/DRG_Default.cs
+++ b/BasicRotations/Melee/DRG_Default.cs
@@ -103,7 +103,7 @@ public sealed class DRG_Default : DragoonRotation
         bool doomSpikeRightNow = DoomSpikeWhenever;
 
         if (CoerthanTormentPvE.CanUse(out act)) return true;
-        if (SonicThrustPvE.CanUse(out act)) return true;
+        if (SonicThrustPvE.CanUse(out act, skipStatusProvideCheck: true)) return true;
         if (DoomSpikePvE.CanUse(out act, skipComboCheck: doomSpikeRightNow)) return true;
 
         if (DrakesbanePvE.CanUse(out act)) return true;

--- a/BasicRotations/Melee/NIN_Default.cs
+++ b/BasicRotations/Melee/NIN_Default.cs
@@ -19,6 +19,7 @@ public sealed class NIN_Default : NinjaRotation
     // Logic to determine the action to take during the countdown phase before combat starts.
     protected override IAction? CountDownAction(float remainTime)
     {
+        var realInHuton = IsLastAction(false, HutonPvE);
         // Clears ninjutsu setup if countdown is more than 6 seconds or if Suiton is the aim but shouldn't be.
         if (remainTime > 6) ClearNinjutsu();
 

--- a/BasicRotations/RebornRotations.csproj
+++ b/BasicRotations/RebornRotations.csproj
@@ -9,7 +9,7 @@
     <None Remove="Duty\PVPRotations\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.4" />
+    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.5" />
   </ItemGroup>
   <ItemGroup>
 	  <Reference Include="Dalamud">


### PR DESCRIPTION
PCT: now uses mits
RDM: you can now do more than use vercure in rotation config 4 times
DRG: aoe rotation restored, dungeon runners rejoice
NIN: Removed Huton from prepull
VPR: added configs and internal logic, now allows you to set how many stacks of Uncoiled Fury you want to use up while in melee out of burst, if in a 2 minute burst window will use all stacks regardless
BRD: hella optimization, now pools bloodletter stacks better and keeps from overcapping due to Mage song