### PR TITLE
Round of fixes

### DIFF
--- a/BasicRotations/Duty/VariantDefault.cs
+++ b/BasicRotations/Duty/VariantDefault.cs
@@ -23,8 +23,8 @@ internal class VariantDefault : VariantRotation
 
     public override bool HealSingleGCD(out IAction? act)
     {
-        if (VariantCurePvE.CanUse(out act)) return true;
-        if (VariantCurePvE_33862.CanUse(out act)) return true;
+        if (VariantCurePvE.CanUse(out act, skipStatusProvideCheck: true)) return true;
+        if (VariantCurePvE_33862.CanUse(out act, skipStatusProvideCheck: true)) return true;
         return base.HealSingleGCD(out act);
     }
 

--- a/BasicRotations/Healer/AST_Default.cs
+++ b/BasicRotations/Healer/AST_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Healer;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.0")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.05")]
 [SourceCode(Path = "main/DefaultRotations/Healer/AST_Default.cs")]
 [Api(3)]
 public sealed class AST_Default : AstrologianRotation
@@ -8,6 +8,9 @@ public sealed class AST_Default : AstrologianRotation
     #region Config Options
     [RotationConfig(CombatType.PvE, Name = "Use spells with cast times to heal. (Ignored if you are the only healer in party)")]
     public bool GCDHeal { get; set; } = false;
+
+    [RotationConfig(CombatType.PvE, Name = "Prevent actions while you have the bubble mit up")]
+    public bool BubbleProtec { get; set; } = false;
 
     [Range(4, 20, ConfigUnitType.Seconds)]
     [RotationConfig(CombatType.PvE, Name = "Use Earthly Star during countdown timer.")]
@@ -42,6 +45,9 @@ public sealed class AST_Default : AstrologianRotation
     [RotationDesc(ActionID.ExaltationPvE, ActionID.TheArrowPvE, ActionID.TheSpirePvE, ActionID.TheBolePvE, ActionID.TheEwerPvE)]
     protected override bool DefenseSingleAbility(IAction nextGCD, out IAction? act)
     {
+        act = null;
+        if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
+
         if (InCombat && TheSpirePvE.CanUse(out act)) return true;
         if (InCombat && TheBolePvE.CanUse(out act)) return true;
 
@@ -53,6 +59,8 @@ public sealed class AST_Default : AstrologianRotation
     protected override bool DefenseAreaGCD(out IAction? act)
     {
         act = null;
+        if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
+
         if (MacrocosmosPvE.Cooldown.IsCoolingDown && !MacrocosmosPvE.Cooldown.WillHaveOneCharge(150)
             || CollectiveUnconsciousPvE.Cooldown.IsCoolingDown && !CollectiveUnconsciousPvE.Cooldown.WillHaveOneCharge(40)) return false;
 
@@ -63,13 +71,15 @@ public sealed class AST_Default : AstrologianRotation
     [RotationDesc(ActionID.CollectiveUnconsciousPvE, ActionID.SunSignPvE)]
     protected override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
     {
+        if (SunSignPvE.CanUse(out act)) return true;
+
         act = null;
+        if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
+
         if (MacrocosmosPvE.Cooldown.IsCoolingDown && !MacrocosmosPvE.Cooldown.WillHaveOneCharge(150)
             || CollectiveUnconsciousPvE.Cooldown.IsCoolingDown && !CollectiveUnconsciousPvE.Cooldown.WillHaveOneCharge(40)) return false;
 
         if (CollectiveUnconsciousPvE.CanUse(out act)) return true;
-
-        if (SunSignPvE.CanUse(out act)) return true;
         return base.DefenseAreaAbility(nextGCD, out act);
     }
     #endregion
@@ -77,6 +87,9 @@ public sealed class AST_Default : AstrologianRotation
     #region GCD Logic
     protected override bool GeneralGCD(out IAction? act)
     {
+        act = null;
+        if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
+
         if (GravityPvE.CanUse(out act)) return true;
 
         if (CombustPvE.CanUse(out act)) return true;
@@ -89,6 +102,9 @@ public sealed class AST_Default : AstrologianRotation
     [RotationDesc(ActionID.AspectedBeneficPvE, ActionID.BeneficIiPvE, ActionID.BeneficPvE)]
     protected override bool HealSingleGCD(out IAction? act)
     {
+        act = null;
+        if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
+
         if (AspectedBeneficPvE.CanUse(out act)
             && (IsMoving
             || AspectedBeneficPvE.Target.Target?.GetHealthRatio() > AspectedBeneficHeal)) return true;
@@ -102,6 +118,9 @@ public sealed class AST_Default : AstrologianRotation
     [RotationDesc(ActionID.AspectedHeliosPvE, ActionID.HeliosPvE)]
     protected override bool HealAreaGCD(out IAction? act)
     {
+        act = null;
+        if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
+
         if (AspectedHeliosPvE.CanUse(out act)) return true;
         if (HeliosPvE.CanUse(out act)) return true;
         return base.HealAreaGCD(out act);
@@ -111,10 +130,14 @@ public sealed class AST_Default : AstrologianRotation
     #region oGCD Logic
     protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
     {
+        act = null;
+        if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
+
         if (base.EmergencyAbility(nextGCD, out act)) return true;
 
         if (!InCombat) return false;
 
+        if (OraclePvE.CanUse(out act)) return true;
         if (nextGCD.IsTheSameTo(true, AspectedHeliosPvE, HeliosPvE))
         {
             if (HoroscopePvE.CanUse(out act)) return true;
@@ -130,6 +153,9 @@ public sealed class AST_Default : AstrologianRotation
 
     protected override bool GeneralAbility(IAction nextGCD, out IAction? act)
     {
+        act = null;
+        if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
+
         if (AstralDrawPvE.CanUse(out act)) return true;
         if (UmbralDrawPvE.CanUse(out act)) return true;
         if (InCombat && TheBalancePvE.CanUse(out act)) return true;
@@ -139,6 +165,9 @@ public sealed class AST_Default : AstrologianRotation
 
     protected override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
+        act = null;
+        if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
+
         if (IsBurst && !IsMoving
             && DivinationPvE.CanUse(out act)) return true;
 
@@ -160,8 +189,6 @@ public sealed class AST_Default : AstrologianRotation
                 if (LordOfCrownsPvE.CanUse(out act)) return true;
             }
         }
-
-        if (OraclePvE.CanUse(out act)) return true;
         return base.AttackAbility(nextGCD, out act);
     }
 
@@ -169,6 +196,9 @@ public sealed class AST_Default : AstrologianRotation
         ActionID.CelestialIntersectionPvE)]
     protected override bool HealSingleAbility(IAction nextGCD, out IAction? act)
     {
+        act = null;
+        if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
+
         if (InCombat && TheArrowPvE.CanUse(out act)) return true;
         if (InCombat && TheEwerPvE.CanUse(out act)) return true;
 
@@ -182,6 +212,11 @@ public sealed class AST_Default : AstrologianRotation
     [RotationDesc(ActionID.CelestialOppositionPvE, ActionID.StellarDetonationPvE, ActionID.HoroscopePvE, ActionID.HoroscopePvE_16558, ActionID.LadyOfCrownsPvE, ActionID.HeliosConjunctionPvE)]
     protected override bool HealAreaAbility(IAction nextGCD, out IAction? act)
     {
+        act = null;
+        if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
+
+        if (MicrocosmosPvE.CanUse(out act)) return true;
+
         if (CelestialOppositionPvE.CanUse(out act)) return true;
 
         if (StellarDetonationPvE.CanUse(out act)) return true;

--- a/BasicRotations/Healer/WHM_Default.cs
+++ b/BasicRotations/Healer/WHM_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Healer;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.00")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.05")]
 [SourceCode(Path = "main/DefaultRotations/Healer/WHM_Default.cs")]
 [Api(3)]
 public sealed class WHM_Default : WhiteMageRotation
@@ -64,10 +64,13 @@ public sealed class WHM_Default : WhiteMageRotation
     protected override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
     {
         act = null;
+
         if (TemperancePvE.Cooldown.IsCoolingDown && !TemperancePvE.Cooldown.WillHaveOneCharge(100)
             || LiturgyOfTheBellPvE.Cooldown.IsCoolingDown && !LiturgyOfTheBellPvE.Cooldown.WillHaveOneCharge(160)) return false;
 
         if (TemperancePvE.CanUse(out act)) return true;
+
+        if (DivineCaressPvE.CanUse(out act)) return true;
 
         if (LiturgyOfTheBellPvE.CanUse(out act, skipAoeCheck: true)) return true;
         return base.DefenseAreaAbility(nextGCD, out act);
@@ -89,7 +92,6 @@ public sealed class WHM_Default : WhiteMageRotation
     [RotationDesc(ActionID.AsylumPvE)]
     protected override bool HealAreaAbility(IAction nextGCD, out IAction? act)
     {
-        if (DivineCaressPvE.CanUse(out act)) return true;
         if (AsylumPvE.CanUse(out act)) return true;
         return base.HealAreaAbility(nextGCD, out act);
     }

--- a/BasicRotations/Melee/VPR_Default.cs
+++ b/BasicRotations/Melee/VPR_Default.cs
@@ -14,6 +14,10 @@ public sealed class VPR_Default : ViperRotation
     [RotationConfig(CombatType.PvE, Name = "How many charges of Uncoiled Fury needs to be at before be used inside of melee (Ignores burst, leave at 3 to hold charges for out of melee uptime or burst only)")]
     public int MaxUncoiledStacksUser { get; set; } = 3;
 
+    [Range(0, 120, ConfigUnitType.None, 5)]
+    [RotationConfig(CombatType.PvE, Name = "How long has to pass on Serpents Ire's cooldown before the rotation starts pooling gauge for burst. Leave this alone if you dont know what youre doing. (Will still use Reawaken if you reach cap regardless of timer)")]
+    public int ReawakenDelayTimer { get; set; } = 75;
+
     #endregion
 
     #region Additional oGCD Logic
@@ -83,7 +87,11 @@ public sealed class VPR_Default : ViperRotation
         if (SwiftTime > 10 &&
             HuntersTime > 10 &&
             !HasHunterVenom && !HasSwiftVenom &&
-            !HasPoisedBlood && !HasPoisedFang)
+            !HasPoisedBlood && !HasPoisedFang && SerpentsIrePvE.EnoughLevel && (!SerpentsIrePvE.Cooldown.ElapsedAfter(ReawakenDelayTimer) || SerpentOffering == 100) ||
+            SwiftTime > 10 &&
+            HuntersTime > 10 &&
+            !HasHunterVenom && !HasSwiftVenom &&
+            !HasPoisedBlood && !HasPoisedFang && !SerpentsIrePvE.EnoughLevel)
         {
             if (ReawakenPvE.CanUse(out act, skipComboCheck: true)) return true;
         }
@@ -104,7 +112,6 @@ public sealed class VPR_Default : ViperRotation
         {
             if (UncoiledFuryPvE.CanUse(out act, usedUp: true)) return true;
         }
-
 
         ////AOE Dread Combo
         if (SwiftskinsDenPvE.CanUse(out act, skipComboCheck: true)) return true;

--- a/BasicRotations/RebornRotations.csproj
+++ b/BasicRotations/RebornRotations.csproj
@@ -16,7 +16,7 @@
     <Compile Include="Duty\EmanationDefault" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.19" />
+    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.29" />
   </ItemGroup>
   <ItemGroup>
 	  <Reference Include="Dalamud">


### PR DESCRIPTION
Updated `VariantDefault`, `AST_Default`, `WHM_Default`, and `VPR_Default` classes.

Key changes include:

- `VariantDefault.cs`: Added `skipStatusProvideCheck` parameter to fix issue not being used.
- `AST_Default.cs`: Added `BubbleProtec` config, and adjusted defensive logic methods, potential fix for Oracle, Microcosmos and Collective whatever the fuck its called.
- `WHM_Default.cs`: Modified `DefenseAreaAbility` and `HealAreaAbility` methods, potential fix for Divine Caress.
- `VPR_Default.cs`: Added `ReawakenDelayTimer` config`.
- `RebornRotations.csproj`: nuget bump