### PR TITLE
Add MicroPrio option and update AOE ability checks

### DIFF
--- a/BasicRotations/Healer/AST_Default.cs
+++ b/BasicRotations/Healer/AST_Default.cs
@@ -11,6 +11,9 @@ public sealed class AST_Default : AstrologianRotation
 
     [RotationConfig(CombatType.PvE, Name = "Prevent actions while you have the bubble mit up")]
     public bool BubbleProtec { get; set; } = false;
+    
+    [RotationConfig(CombatType.PvE, Name = "Prioritize Microcosmos over all other healing when available")]
+    public bool MicroPrio { get; set; } = false;
 
     [Range(4, 20, ConfigUnitType.Seconds)]
     [RotationConfig(CombatType.PvE, Name = "Use Earthly Star during countdown timer.")]
@@ -104,6 +107,7 @@ public sealed class AST_Default : AstrologianRotation
     {
         act = null;
         if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
+        if (MicroPrio && Player.HasStatus(true, StatusID.Macrocosmos)) return false;
 
         if (AspectedBeneficPvE.CanUse(out act)
             && (IsMoving
@@ -120,6 +124,7 @@ public sealed class AST_Default : AstrologianRotation
     {
         act = null;
         if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
+        if (MicroPrio && Player.HasStatus(true, StatusID.Macrocosmos)) return false;
 
         if (AspectedHeliosPvE.CanUse(out act)) return true;
         if (HeliosPvE.CanUse(out act)) return true;
@@ -132,6 +137,7 @@ public sealed class AST_Default : AstrologianRotation
     {
         act = null;
         if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
+        if (MicroPrio && Player.HasStatus(true, StatusID.Macrocosmos)) return false;
 
         if (base.EmergencyAbility(nextGCD, out act)) return true;
 
@@ -198,6 +204,7 @@ public sealed class AST_Default : AstrologianRotation
     {
         act = null;
         if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
+        if (MicroPrio && Player.HasStatus(true, StatusID.Macrocosmos)) return false;
 
         if (InCombat && TheArrowPvE.CanUse(out act)) return true;
         if (InCombat && TheEwerPvE.CanUse(out act)) return true;
@@ -216,6 +223,7 @@ public sealed class AST_Default : AstrologianRotation
         if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
 
         if (MicrocosmosPvE.CanUse(out act)) return true;
+        if (MicroPrio && Player.HasStatus(true, StatusID.Macrocosmos)) return false;
 
         if (CelestialOppositionPvE.CanUse(out act)) return true;
 

--- a/BasicRotations/Melee/VPR_Default.cs
+++ b/BasicRotations/Melee/VPR_Default.cs
@@ -29,8 +29,8 @@ public sealed class VPR_Default : ViperRotation
         if (UncoiledTwinbloodPvE.CanUse(out act)) return true;
 
         //AOE Dread Combo
-        if (TwinfangThreshPvE.CanUse(out act)) return true;
-        if (TwinbloodThreshPvE.CanUse(out act)) return true;
+        if (TwinfangThreshPvE.CanUse(out act, skipAoeCheck: true)) return true;
+        if (TwinbloodThreshPvE.CanUse(out act, skipAoeCheck: true)) return true;
 
         //Single Target Dread Combo
         if (TwinfangBitePvE.CanUse(out act)) return true;
@@ -114,8 +114,8 @@ public sealed class VPR_Default : ViperRotation
         }
 
         ////AOE Dread Combo
-        if (SwiftskinsDenPvE.CanUse(out act, skipComboCheck: true)) return true;
-        if (HuntersDenPvE.CanUse(out act, skipComboCheck: true)) return true;
+        if (SwiftskinsDenPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true)) return true;
+        if (HuntersDenPvE.CanUse(out act, skipComboCheck: true, skipAoeCheck: true)) return true;
 
         if (VicepitPvE.Cooldown.CurrentCharges == 1 && VicepitPvE.Cooldown.RecastTimeRemainOneCharge < 10)
         {


### PR DESCRIPTION
Added a new `MicroPrio` configuration to `AST_Default` to prioritize `Microcosmos` over other healing actions. Updated several methods in `AST_Default` to respect `MicroPrio` and `Macrocosmos` status, preventing other actions when active. Modified `VPR_Default` to allow specific AOE abilities to bypass AOE checks with `skipAoeCheck: true`.