### PR TITLE
VPR AOE fixes and formatting fixes

### DIFF
--- a/BasicRotations/Healer/AST_Default.cs
+++ b/BasicRotations/Healer/AST_Default.cs
@@ -11,7 +11,7 @@ public sealed class AST_Default : AstrologianRotation
 
     [RotationConfig(CombatType.PvE, Name = "Prevent actions while you have the bubble mit up")]
     public bool BubbleProtec { get; set; } = false;
-    
+
     [RotationConfig(CombatType.PvE, Name = "Prioritize Microcosmos over all other healing when available")]
     public bool MicroPrio { get; set; } = false;
 

--- a/BasicRotations/Magical/ICWA_PCT_BETA.cs
+++ b/BasicRotations/Magical/ICWA_PCT_BETA.cs
@@ -7,247 +7,247 @@ namespace DefaultRotations.Magical;
 [Api(3)]
 public sealed class IcWaPctBeta : PictomancerRotation
 {
-	public override MedicineType MedicineType => MedicineType.Intelligence;
-	public static IBaseAction RainbowPrePull { get; } = new BaseAction((ActionID)34688);
-	[RotationConfig(CombatType.PvE, Name = "Use HolyInWhite or CometInBlack while moving")]
-	public bool HolyCometMoving { get; set; } = true;
-	[RotationConfig(CombatType.PvE, Name = "Use swifcast on (would advise weapon only - Creature can delay timings and f opener and reopener and landscape doesn't bring any bonus on dps.)")]
-	public MotifSwift MotifSwiftCast { get; set; } = MotifSwift.WeaponMotif;
-	[Range(1, 5, ConfigUnitType.None, 1)]
-	[RotationConfig(CombatType.PvE, Name = "Paint overcap protection. How many paint do you need to be at before using a paint?")]
-	public bool UseCapCometHoly { get; set; } = true;
-	[RotationConfig(CombatType.PvE, Name = "Use the paint overcap protection (will still use comet while moving if the setup is on)")]
-	public bool UseCapCometOnly { get; set; } = false;
-	[RotationConfig(CombatType.PvE, Name = "Use the paint overcap protection for comet only (will still use comet while moving if the setup is on)")]
-	public int HolyCometMax { get; set; } = 5;
-	public enum MotifSwift : byte
-	{
-		[Description("CreatureMotif")] CreatureMotif,
-		[Description("WeaponMotif")] WeaponMotif,
-		[Description("LandscapeMotif")] LandscapeMotif,
-		[Description("AllMotif")] AllMotif,
-		[Description("NoMotif(ManualSwifcast")] NoMotif
-	}
-	#region Countdown logic
-	// Defines logic for actions to take during the countdown before combat starts.
-	protected override IAction? CountDownAction(float remainTime)
-	{
-		IAction act;
-		if (!InCombat)
-		{
-			if (!CreatureMotifDrawn)
-			{
-				if (PomMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == PomMotifPvE.ID) return act;
-				if (WingMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == WingMotifPvE.ID) return act;
-				if (ClawMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == ClawMotifPvE.ID) return act;
-				if (MawMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == MawMotifPvE.ID) return act;
-			}
-			if (!WeaponMotifDrawn)
-			{
-				if (HammerMotifPvE.CanUse(out act)) return act;
-			}
-			if (!LandscapeMotifDrawn)
-			{
-				if (StarrySkyMotifPvE.CanUse(out act) && !Player.HasStatus(true, StatusID.Hyperphantasia)) return act;
-			}
-		}
-		if (remainTime < RainbowDripPvE.Info.CastTime + CountDownAhead)
-		{
-			if (StrikingMusePvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true) && WeaponMotifDrawn) return act;
-		}
-		if (remainTime < RainbowDripPvE.Info.CastTime + 0.4f + CountDownAhead)
-		{
-			if (RainbowPrePull.CanUse(out act, skipAoeCheck: true, skipCastingCheck: true, skipStatusProvideCheck: true)) return act;
-		}
-		if (remainTime < FireInRedPvE.Info.CastTime + CountDownAhead && Player.Level < 92)
-		{
-			if (FireInRedPvE.CanUse(out act, skipAoeCheck: true, skipCastingCheck: true, skipStatusProvideCheck: true)) return act;
-		}
-		return base.CountDownAction(remainTime);
-	}
-	#endregion
+    public override MedicineType MedicineType => MedicineType.Intelligence;
+    public static IBaseAction RainbowPrePull { get; } = new BaseAction((ActionID)34688);
+    [RotationConfig(CombatType.PvE, Name = "Use HolyInWhite or CometInBlack while moving")]
+    public bool HolyCometMoving { get; set; } = true;
+    [RotationConfig(CombatType.PvE, Name = "Use swifcast on (would advise weapon only - Creature can delay timings and f opener and reopener and landscape doesn't bring any bonus on dps.)")]
+    public MotifSwift MotifSwiftCast { get; set; } = MotifSwift.WeaponMotif;
+    [Range(1, 5, ConfigUnitType.None, 1)]
+    [RotationConfig(CombatType.PvE, Name = "Paint overcap protection. How many paint do you need to be at before using a paint?")]
+    public bool UseCapCometHoly { get; set; } = true;
+    [RotationConfig(CombatType.PvE, Name = "Use the paint overcap protection (will still use comet while moving if the setup is on)")]
+    public bool UseCapCometOnly { get; set; } = false;
+    [RotationConfig(CombatType.PvE, Name = "Use the paint overcap protection for comet only (will still use comet while moving if the setup is on)")]
+    public int HolyCometMax { get; set; } = 5;
+    public enum MotifSwift : byte
+    {
+        [Description("CreatureMotif")] CreatureMotif,
+        [Description("WeaponMotif")] WeaponMotif,
+        [Description("LandscapeMotif")] LandscapeMotif,
+        [Description("AllMotif")] AllMotif,
+        [Description("NoMotif(ManualSwifcast")] NoMotif
+    }
+    #region Countdown logic
+    // Defines logic for actions to take during the countdown before combat starts.
+    protected override IAction? CountDownAction(float remainTime)
+    {
+        IAction act;
+        if (!InCombat)
+        {
+            if (!CreatureMotifDrawn)
+            {
+                if (PomMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == PomMotifPvE.ID) return act;
+                if (WingMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == WingMotifPvE.ID) return act;
+                if (ClawMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == ClawMotifPvE.ID) return act;
+                if (MawMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == MawMotifPvE.ID) return act;
+            }
+            if (!WeaponMotifDrawn)
+            {
+                if (HammerMotifPvE.CanUse(out act)) return act;
+            }
+            if (!LandscapeMotifDrawn)
+            {
+                if (StarrySkyMotifPvE.CanUse(out act) && !Player.HasStatus(true, StatusID.Hyperphantasia)) return act;
+            }
+        }
+        if (remainTime < RainbowDripPvE.Info.CastTime + CountDownAhead)
+        {
+            if (StrikingMusePvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true) && WeaponMotifDrawn) return act;
+        }
+        if (remainTime < RainbowDripPvE.Info.CastTime + 0.4f + CountDownAhead)
+        {
+            if (RainbowPrePull.CanUse(out act, skipAoeCheck: true, skipCastingCheck: true, skipStatusProvideCheck: true)) return act;
+        }
+        if (remainTime < FireInRedPvE.Info.CastTime + CountDownAhead && Player.Level < 92)
+        {
+            if (FireInRedPvE.CanUse(out act, skipAoeCheck: true, skipCastingCheck: true, skipStatusProvideCheck: true)) return act;
+        }
+        return base.CountDownAction(remainTime);
+    }
+    #endregion
 
-	#region Additional oGCD Logic
-	protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
-	{
-		if (InCombat)
-		{
-			switch (MotifSwiftCast)
-			{
-			case MotifSwift.CreatureMotif:
-				if (nextGCD == PomMotifPvE || nextGCD == WingMotifPvE || nextGCD == MawMotifPvE || nextGCD == ClawMotifPvE)
-				{
-					if (SwiftcastPvE.CanUse(out act)) return true;
-				}
-				break;
-			case MotifSwift.WeaponMotif:
-				if (nextGCD == HammerMotifPvE)
-				{
-					if (SwiftcastPvE.CanUse(out act)) return true;
-				}
-				break;
-			case MotifSwift.LandscapeMotif:
-				if (nextGCD == StarrySkyMotifPvE)
-				{
-					if (SwiftcastPvE.CanUse(out act)) return true;
-				}
-				break;
-			case MotifSwift.AllMotif:
-				if (nextGCD == PomMotifPvE || nextGCD == WingMotifPvE || nextGCD == MawMotifPvE || nextGCD == ClawMotifPvE)
-				{
-					if (SwiftcastPvE.CanUse(out act)) return true;
-				}
-				else if (nextGCD == HammerMotifPvE)
-				{
-					if (SwiftcastPvE.CanUse(out act)) return true;
-				}
-				else if (nextGCD == StarrySkyMotifPvE)
-				{
-					if (SwiftcastPvE.CanUse(out act)) return true;
-				}
-				break;
-			case MotifSwift.NoMotif:
-				break;
-			}
-		}
-		return base.EmergencyAbility(nextGCD, out act);
-	}
+    #region Additional oGCD Logic
+    protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
+    {
+        if (InCombat)
+        {
+            switch (MotifSwiftCast)
+            {
+                case MotifSwift.CreatureMotif:
+                    if (nextGCD == PomMotifPvE || nextGCD == WingMotifPvE || nextGCD == MawMotifPvE || nextGCD == ClawMotifPvE)
+                    {
+                        if (SwiftcastPvE.CanUse(out act)) return true;
+                    }
+                    break;
+                case MotifSwift.WeaponMotif:
+                    if (nextGCD == HammerMotifPvE)
+                    {
+                        if (SwiftcastPvE.CanUse(out act)) return true;
+                    }
+                    break;
+                case MotifSwift.LandscapeMotif:
+                    if (nextGCD == StarrySkyMotifPvE)
+                    {
+                        if (SwiftcastPvE.CanUse(out act)) return true;
+                    }
+                    break;
+                case MotifSwift.AllMotif:
+                    if (nextGCD == PomMotifPvE || nextGCD == WingMotifPvE || nextGCD == MawMotifPvE || nextGCD == ClawMotifPvE)
+                    {
+                        if (SwiftcastPvE.CanUse(out act)) return true;
+                    }
+                    else if (nextGCD == HammerMotifPvE)
+                    {
+                        if (SwiftcastPvE.CanUse(out act)) return true;
+                    }
+                    else if (nextGCD == StarrySkyMotifPvE)
+                    {
+                        if (SwiftcastPvE.CanUse(out act)) return true;
+                    }
+                    break;
+                case MotifSwift.NoMotif:
+                    break;
+            }
+        }
+        return base.EmergencyAbility(nextGCD, out act);
+    }
 
-	[RotationDesc(ActionID.SmudgePvE)]
-	protected override bool MoveForwardAbility(IAction nextGCD, out IAction? act)
-	{
-		if (SmudgePvE.CanUse(out act)) return true;
-		return base.AttackAbility(nextGCD, out act);
-	}
+    [RotationDesc(ActionID.SmudgePvE)]
+    protected override bool MoveForwardAbility(IAction nextGCD, out IAction? act)
+    {
+        if (SmudgePvE.CanUse(out act)) return true;
+        return base.AttackAbility(nextGCD, out act);
+    }
 
-	[RotationDesc(ActionID.AddlePvE, ActionID.TemperaCoatPvE, ActionID.TemperaGrassaPvE)]
-	protected override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
-	{
-		if (AddlePvE.CanUse(out act)) return true;
-		if (TemperaCoatPvE.CanUse(out act)) return true;
-		if (TemperaGrassaPvE.CanUse(out act)) return true;
-		return base.DefenseAreaAbility(nextGCD, out act);
-	}
-	#endregion
+    [RotationDesc(ActionID.AddlePvE, ActionID.TemperaCoatPvE, ActionID.TemperaGrassaPvE)]
+    protected override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
+    {
+        if (AddlePvE.CanUse(out act)) return true;
+        if (TemperaCoatPvE.CanUse(out act)) return true;
+        if (TemperaGrassaPvE.CanUse(out act)) return true;
+        return base.DefenseAreaAbility(nextGCD, out act);
+    }
+    #endregion
 
-	#region oGCD Logic
-	protected override bool AttackAbility(IAction nextGCD, out IAction? act)
-	{
-		bool burstTimingCheckerStriking = !ScenicMusePvE.Cooldown.WillHaveOneCharge(60) || Player.HasStatus(true, StatusID.StarryMuse);
-		int adjustCombatTimeForOpener = Player.Level < 92 ? 2 : 5;
-		if (ScenicMusePvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true) && CombatTime > adjustCombatTimeForOpener && IsBurst) return true;
-		if (CombatTime > adjustCombatTimeForOpener && StrikingMusePvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true) && burstTimingCheckerStriking) return true;
-		if (SubtractivePalettePvE.CanUse(out act) && !Player.HasStatus(true, StatusID.SubtractivePalette)) return true;
-		if (Player.HasStatus(true, StatusID.StarryMuse))
-		{
-			if (FangedMusePvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true)) return true;
-			if (RetributionOfTheMadeenPvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true)) return true;
-		}
-		if (RetributionOfTheMadeenPvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true)) return true;
-		if (MogOfTheAgesPvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true)) return true;
-		if (StrikingMusePvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true) && burstTimingCheckerStriking) return true;
-		if (PomMusePvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true) && LivingMusePvE.AdjustedID == PomMusePvE.ID) return true;
-		if (WingedMusePvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true) && LivingMusePvE.AdjustedID == WingedMusePvE.ID) return true;
-		if (ClawedMusePvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true) && LivingMusePvE.AdjustedID == ClawedMusePvE.ID) return true;
-		return base.AttackAbility(nextGCD, out act);
-	}
-	#endregion
+    #region oGCD Logic
+    protected override bool AttackAbility(IAction nextGCD, out IAction? act)
+    {
+        bool burstTimingCheckerStriking = !ScenicMusePvE.Cooldown.WillHaveOneCharge(60) || Player.HasStatus(true, StatusID.StarryMuse);
+        int adjustCombatTimeForOpener = Player.Level < 92 ? 2 : 5;
+        if (ScenicMusePvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true) && CombatTime > adjustCombatTimeForOpener && IsBurst) return true;
+        if (CombatTime > adjustCombatTimeForOpener && StrikingMusePvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true) && burstTimingCheckerStriking) return true;
+        if (SubtractivePalettePvE.CanUse(out act) && !Player.HasStatus(true, StatusID.SubtractivePalette)) return true;
+        if (Player.HasStatus(true, StatusID.StarryMuse))
+        {
+            if (FangedMusePvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true)) return true;
+            if (RetributionOfTheMadeenPvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true)) return true;
+        }
+        if (RetributionOfTheMadeenPvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true)) return true;
+        if (MogOfTheAgesPvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true)) return true;
+        if (StrikingMusePvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true) && burstTimingCheckerStriking) return true;
+        if (PomMusePvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true) && LivingMusePvE.AdjustedID == PomMusePvE.ID) return true;
+        if (WingedMusePvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true) && LivingMusePvE.AdjustedID == WingedMusePvE.ID) return true;
+        if (ClawedMusePvE.CanUse(out act, skipCastingCheck: true, skipStatusProvideCheck: true, skipComboCheck: true, skipAoeCheck: true, usedUp: true) && LivingMusePvE.AdjustedID == ClawedMusePvE.ID) return true;
+        return base.AttackAbility(nextGCD, out act);
+    }
+    #endregion
 
-	#region GCD Logic
-	protected override bool GeneralGCD(out IAction? act)
-	{
-		//Opener requirements
-		if (CombatTime < 5)
-		{
-			if (HolyInWhitePvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true) && Paint > 0) return true;
-			if (PomMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == PomMotifPvE.ID) return true;
-			if (WingMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == WingMotifPvE.ID) return true;
-			if (ClawMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == ClawMotifPvE.ID) return true;
-			if (MawMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == MawMotifPvE.ID) return true;
-		}
-		// some gcd priority
-		if (RainbowDripPvE.CanUse(out act, skipAoeCheck: true) && Player.HasStatus(true, StatusID.RainbowBright)) return true;
-		if (Player.HasStatus(true, StatusID.StarryMuse))
-		{
-			if (CometInBlackPvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true) && Paint > 0) return true;
-		}
-		if (StarPrismPvE.CanUse(out act, skipAoeCheck: true) && Player.HasStatus(true, StatusID.Starstruck)) return true;
-		if (HammerStampPvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true) && HasHammerTime) return true;
-		//Cast when not in fight or no target available
-		if (!InCombat)
-		{
-			if (PomMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == PomMotifPvE.ID) return true;
-			if (WingMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == WingMotifPvE.ID) return true;
-			if (ClawMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == ClawMotifPvE.ID) return true;
-			if (MawMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == MawMotifPvE.ID) return true;
-			if (HammerMotifPvE.CanUse(out act)) return true;
-			if (StarrySkyMotifPvE.CanUse(out act) && !Player.HasStatus(true, StatusID.Hyperphantasia)) return true;
-			if (RainbowDripPvE.CanUse(out act)) return true;
-		}
-		// timings for motif casting
-		if (ScenicMusePvE.Cooldown.RecastTimeRemainOneCharge <= 15 && !Player.HasStatus(true, StatusID.StarryMuse) && !Player.HasStatus(true, StatusID.Hyperphantasia))
-		{
-			if (StarrySkyMotifPvE.CanUse(out act) && !Player.HasStatus(true, StatusID.Hyperphantasia)) return true;
-		}
-		if ((LivingMusePvE.Cooldown.HasOneCharge || LivingMusePvE.Cooldown.RecastTimeRemainOneCharge <= CreatureMotifPvE.Info.CastTime * 1.7) && !Player.HasStatus(true, StatusID.StarryMuse) && !Player.HasStatus(true, StatusID.Hyperphantasia))
-		{
-			if (PomMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == PomMotifPvE.ID) return true;
-			if (WingMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == WingMotifPvE.ID) return true;
-			if (ClawMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == ClawMotifPvE.ID) return true;
-			if (MawMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == MawMotifPvE.ID) return true;
-			;
-		}
-		if ((SteelMusePvE.Cooldown.HasOneCharge || SteelMusePvE.Cooldown.RecastTimeRemainOneCharge <= WeaponMotifPvE.Info.CastTime) && !Player.HasStatus(true, StatusID.StarryMuse) && !Player.HasStatus(true, StatusID.Hyperphantasia))
-		{
-			if (HammerMotifPvE.CanUse(out act)) return true;
-		}
-		bool isMovingAndSwift = IsMoving && !Player.HasStatus(true, StatusID.Swiftcast);
-		// white/black paint use while moving
-		if (isMovingAndSwift)
-		{
-			if (HammerStampPvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true)) return true;
-			if (HolyCometMoving)
-			{
-				if (CometInBlackPvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true)) return true;
-				if (HolyInWhitePvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true)) return true;
-			}
-		}
-		// When in swift management
-		if (Player.HasStatus(true, StatusID.Swiftcast) && (!LandscapeMotifDrawn || !CreatureMotifDrawn || !WeaponMotifDrawn))
-		{
-			bool creature = MotifSwiftCast is MotifSwift.CreatureMotif or MotifSwift.AllMotif;
-			bool weapon = MotifSwiftCast is MotifSwift.WeaponMotif or MotifSwift.AllMotif;
-			bool landscape = MotifSwiftCast is MotifSwift.LandscapeMotif or MotifSwift.AllMotif;
-			if (PomMotifPvE.CanUse(out act, skipCastingCheck: creature) && CreatureMotifPvE.AdjustedID == PomMotifPvE.ID && creature) return true;
-			if (WingMotifPvE.CanUse(out act, skipCastingCheck: creature) && CreatureMotifPvE.AdjustedID == WingMotifPvE.ID && creature) return true;
-			if (ClawMotifPvE.CanUse(out act, skipCastingCheck: creature) && CreatureMotifPvE.AdjustedID == ClawMotifPvE.ID && creature) return true;
-			if (MawMotifPvE.CanUse(out act, skipCastingCheck: creature) && CreatureMotifPvE.AdjustedID == MawMotifPvE.ID && creature) return true;
-			if (HammerMotifPvE.CanUse(out act, skipCastingCheck: weapon) && weapon) return true;
-			if (StarrySkyMotifPvE.CanUse(out act, skipCastingCheck: landscape) && !Player.HasStatus(true, StatusID.Hyperphantasia) && landscape) return true;
-		}
-		//white paint over cap protection
-		if ((Paint == HolyCometMax && !Player.HasStatus(true, StatusID.StarryMuse)) && (UseCapCometHoly || UseCapCometOnly))
-		{
-			if (CometInBlackPvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true)) return true;
-			if (HolyInWhitePvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true) && !UseCapCometOnly) return true;
-		}
-		//aoe sub
-		if (ThunderIiInMagentaPvE.CanUse(out act)) return true;
-		if (StoneIiInYellowPvE.CanUse(out act)) return true;
-		if (BlizzardIiInCyanPvE.CanUse(out act)) return true;
-		//aoe normal
-		if (WaterIiInBluePvE.CanUse(out act)) return true;
-		if (AeroIiInGreenPvE.CanUse(out act)) return true;
-		if (FireIiInRedPvE.CanUse(out act)) return true;
-		//single target sub
-		if (ThunderInMagentaPvE.CanUse(out act)) return true;
-		if (StoneInYellowPvE.CanUse(out act)) return true;
-		if (BlizzardInCyanPvE.CanUse(out act)) return true;
-		//single target normal
-		if (WaterInBluePvE.CanUse(out act)) return true;
-		if (AeroInGreenPvE.CanUse(out act)) return true;
-		if (FireInRedPvE.CanUse(out act)) return true;
-		return base.GeneralGCD(out act);
-	}
-	#endregion
+    #region GCD Logic
+    protected override bool GeneralGCD(out IAction? act)
+    {
+        //Opener requirements
+        if (CombatTime < 5)
+        {
+            if (HolyInWhitePvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true) && Paint > 0) return true;
+            if (PomMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == PomMotifPvE.ID) return true;
+            if (WingMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == WingMotifPvE.ID) return true;
+            if (ClawMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == ClawMotifPvE.ID) return true;
+            if (MawMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == MawMotifPvE.ID) return true;
+        }
+        // some gcd priority
+        if (RainbowDripPvE.CanUse(out act, skipAoeCheck: true) && Player.HasStatus(true, StatusID.RainbowBright)) return true;
+        if (Player.HasStatus(true, StatusID.StarryMuse))
+        {
+            if (CometInBlackPvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true) && Paint > 0) return true;
+        }
+        if (StarPrismPvE.CanUse(out act, skipAoeCheck: true) && Player.HasStatus(true, StatusID.Starstruck)) return true;
+        if (HammerStampPvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true) && HasHammerTime) return true;
+        //Cast when not in fight or no target available
+        if (!InCombat)
+        {
+            if (PomMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == PomMotifPvE.ID) return true;
+            if (WingMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == WingMotifPvE.ID) return true;
+            if (ClawMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == ClawMotifPvE.ID) return true;
+            if (MawMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == MawMotifPvE.ID) return true;
+            if (HammerMotifPvE.CanUse(out act)) return true;
+            if (StarrySkyMotifPvE.CanUse(out act) && !Player.HasStatus(true, StatusID.Hyperphantasia)) return true;
+            if (RainbowDripPvE.CanUse(out act)) return true;
+        }
+        // timings for motif casting
+        if (ScenicMusePvE.Cooldown.RecastTimeRemainOneCharge <= 15 && !Player.HasStatus(true, StatusID.StarryMuse) && !Player.HasStatus(true, StatusID.Hyperphantasia))
+        {
+            if (StarrySkyMotifPvE.CanUse(out act) && !Player.HasStatus(true, StatusID.Hyperphantasia)) return true;
+        }
+        if ((LivingMusePvE.Cooldown.HasOneCharge || LivingMusePvE.Cooldown.RecastTimeRemainOneCharge <= CreatureMotifPvE.Info.CastTime * 1.7) && !Player.HasStatus(true, StatusID.StarryMuse) && !Player.HasStatus(true, StatusID.Hyperphantasia))
+        {
+            if (PomMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == PomMotifPvE.ID) return true;
+            if (WingMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == WingMotifPvE.ID) return true;
+            if (ClawMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == ClawMotifPvE.ID) return true;
+            if (MawMotifPvE.CanUse(out act) && CreatureMotifPvE.AdjustedID == MawMotifPvE.ID) return true;
+            ;
+        }
+        if ((SteelMusePvE.Cooldown.HasOneCharge || SteelMusePvE.Cooldown.RecastTimeRemainOneCharge <= WeaponMotifPvE.Info.CastTime) && !Player.HasStatus(true, StatusID.StarryMuse) && !Player.HasStatus(true, StatusID.Hyperphantasia))
+        {
+            if (HammerMotifPvE.CanUse(out act)) return true;
+        }
+        bool isMovingAndSwift = IsMoving && !Player.HasStatus(true, StatusID.Swiftcast);
+        // white/black paint use while moving
+        if (isMovingAndSwift)
+        {
+            if (HammerStampPvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true)) return true;
+            if (HolyCometMoving)
+            {
+                if (CometInBlackPvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true)) return true;
+                if (HolyInWhitePvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true)) return true;
+            }
+        }
+        // When in swift management
+        if (Player.HasStatus(true, StatusID.Swiftcast) && (!LandscapeMotifDrawn || !CreatureMotifDrawn || !WeaponMotifDrawn))
+        {
+            bool creature = MotifSwiftCast is MotifSwift.CreatureMotif or MotifSwift.AllMotif;
+            bool weapon = MotifSwiftCast is MotifSwift.WeaponMotif or MotifSwift.AllMotif;
+            bool landscape = MotifSwiftCast is MotifSwift.LandscapeMotif or MotifSwift.AllMotif;
+            if (PomMotifPvE.CanUse(out act, skipCastingCheck: creature) && CreatureMotifPvE.AdjustedID == PomMotifPvE.ID && creature) return true;
+            if (WingMotifPvE.CanUse(out act, skipCastingCheck: creature) && CreatureMotifPvE.AdjustedID == WingMotifPvE.ID && creature) return true;
+            if (ClawMotifPvE.CanUse(out act, skipCastingCheck: creature) && CreatureMotifPvE.AdjustedID == ClawMotifPvE.ID && creature) return true;
+            if (MawMotifPvE.CanUse(out act, skipCastingCheck: creature) && CreatureMotifPvE.AdjustedID == MawMotifPvE.ID && creature) return true;
+            if (HammerMotifPvE.CanUse(out act, skipCastingCheck: weapon) && weapon) return true;
+            if (StarrySkyMotifPvE.CanUse(out act, skipCastingCheck: landscape) && !Player.HasStatus(true, StatusID.Hyperphantasia) && landscape) return true;
+        }
+        //white paint over cap protection
+        if ((Paint == HolyCometMax && !Player.HasStatus(true, StatusID.StarryMuse)) && (UseCapCometHoly || UseCapCometOnly))
+        {
+            if (CometInBlackPvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true)) return true;
+            if (HolyInWhitePvE.CanUse(out act, skipCastingCheck: true, skipAoeCheck: true) && !UseCapCometOnly) return true;
+        }
+        //aoe sub
+        if (ThunderIiInMagentaPvE.CanUse(out act)) return true;
+        if (StoneIiInYellowPvE.CanUse(out act)) return true;
+        if (BlizzardIiInCyanPvE.CanUse(out act)) return true;
+        //aoe normal
+        if (WaterIiInBluePvE.CanUse(out act)) return true;
+        if (AeroIiInGreenPvE.CanUse(out act)) return true;
+        if (FireIiInRedPvE.CanUse(out act)) return true;
+        //single target sub
+        if (ThunderInMagentaPvE.CanUse(out act)) return true;
+        if (StoneInYellowPvE.CanUse(out act)) return true;
+        if (BlizzardInCyanPvE.CanUse(out act)) return true;
+        //single target normal
+        if (WaterInBluePvE.CanUse(out act)) return true;
+        if (AeroInGreenPvE.CanUse(out act)) return true;
+        if (FireInRedPvE.CanUse(out act)) return true;
+        return base.GeneralGCD(out act);
+    }
+    #endregion
 }

--- a/BasicRotations/Magical/SMN_Default.cs
+++ b/BasicRotations/Magical/SMN_Default.cs
@@ -8,245 +8,245 @@ namespace DefaultRotations.Magical;
 public sealed class SMN_Default : SummonerRotation
 {
 
-	#region Config Options
+    #region Config Options
 
-	public enum SummonOrderType : byte
-	{
-		[Description("Topaz-Emerald-Ruby")] TopazEmeraldRuby,
+    public enum SummonOrderType : byte
+    {
+        [Description("Topaz-Emerald-Ruby")] TopazEmeraldRuby,
 
-		[Description("Topaz-Ruby-Emerald")] TopazRubyEmerald,
+        [Description("Topaz-Ruby-Emerald")] TopazRubyEmerald,
 
-		[Description("Emerald-Topaz-Ruby")] EmeraldTopazRuby,
-		
-		[Description("Ruby-Emerald-Topaz")] RubyEmeraldTopaz,
-	}
+        [Description("Emerald-Topaz-Ruby")] EmeraldTopazRuby,
 
-	[RotationConfig(CombatType.PvE, Name = "Use Crimson Cyclone. Will use at any range, regardless of saftey use with caution.")]
-	public bool AddCrimsonCyclone { get; set; } = true;
-	
-	[RotationConfig(CombatType.PvE, Name = "Use Crimson Cyclone. Even When MOVING")]
-	public bool AddCrimsonCycloneMoving { get; set; } = false;
+        [Description("Ruby-Emerald-Topaz")] RubyEmeraldTopaz,
+    }
 
-	[RotationConfig(CombatType.PvE, Name = "Use Swiftcast on Garuda")]
-	public bool AddSwiftcastOnGaruda { get; set; } = false;
+    [RotationConfig(CombatType.PvE, Name = "Use Crimson Cyclone. Will use at any range, regardless of saftey use with caution.")]
+    public bool AddCrimsonCyclone { get; set; } = true;
 
-	[RotationConfig(CombatType.PvE, Name = "Order")]
-	public SummonOrderType SummonOrder { get; set; } = SummonOrderType.TopazEmeraldRuby;
+    [RotationConfig(CombatType.PvE, Name = "Use Crimson Cyclone. Even When MOVING")]
+    public bool AddCrimsonCycloneMoving { get; set; } = false;
 
-	[RotationConfig(CombatType.PvE, Name = "Use radiant on cooldown. But still keeping one charge")]
-	public bool RadiantOnCooldown { get; set; } = true;
-	
-	[RotationConfig(CombatType.PvE, Name = "Use this if there's no other raid buff in your party")]
-	public bool SecondTypeOpenerLogic { get; set; } = false;
-	
-	#endregion
+    [RotationConfig(CombatType.PvE, Name = "Use Swiftcast on Garuda")]
+    public bool AddSwiftcastOnGaruda { get; set; } = false;
 
+    [RotationConfig(CombatType.PvE, Name = "Order")]
+    public SummonOrderType SummonOrder { get; set; } = SummonOrderType.TopazEmeraldRuby;
 
-	#region Countdown Logic
-	protected override IAction? CountDownAction(float remainTime)
-	{
-		if (SummonCarbunclePvE.CanUse(out var act)) return act;
+    [RotationConfig(CombatType.PvE, Name = "Use radiant on cooldown. But still keeping one charge")]
+    public bool RadiantOnCooldown { get; set; } = true;
 
-		if (remainTime <= RuinPvE.Info.CastTime + CountDownAhead
-			&& RuinPvE.CanUse(out act)) return act;
-		return base.CountDownAction(remainTime);
-	}
-	#endregion
+    [RotationConfig(CombatType.PvE, Name = "Use this if there's no other raid buff in your party")]
+    public bool SecondTypeOpenerLogic { get; set; } = false;
 
-	#region Move Logic
-	[RotationDesc(ActionID.CrimsonCyclonePvE)]
-	protected override bool MoveForwardGCD(out IAction? act)
-	{
-		if (CrimsonCyclonePvE.CanUse(out act, skipAoeCheck: true)) return true;
-		return base.MoveForwardGCD(out act);
-	}
-	#endregion
+    #endregion
 
 
-	#region oGCD Logic
-	protected override bool AttackAbility(IAction nextGCD, out IAction? act)
-	{
-		bool isTargetBoss = HostileTarget?.IsBossFromTTK() ?? false;
-		bool isTargetDying = HostileTarget?.IsDying() ?? false;
-		bool targetIsBossAndDying = isTargetBoss && isTargetDying;
-		bool inBigInvocation = !SummonBahamutPvE.EnoughLevel || (InBahamut || InPhoenix || InSolarBahamut);
-		bool inSolarUnique = Player.Level == 100 ? !InBahamut && !InPhoenix && InSolarBahamut : InBahamut && !InPhoenix;
-		if (SecondTypeOpenerLogic)
-		{
-			bool elapsed0ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD() || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD() || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD();
-			bool elapsed1ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(1) || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(1) || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD(1);
-			bool elapsed2ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(2) || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(2) || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD(2);
-			bool burstInSolar = Player.Level == 100 ? InSolarBahamut : InBahamut;
+    #region Countdown Logic
+    protected override IAction? CountDownAction(float remainTime)
+    {
+        if (SummonCarbunclePvE.CanUse(out var act)) return act;
 
-			if (!Player.HasStatus(false, StatusID.SearingLight) && burstInSolar && elapsed0ChargeAfterInvocation)
-			{
-				if (SearingLightPvE.CanUse(out act, skipAoeCheck: true)) return true;
-			}
+        if (remainTime <= RuinPvE.Info.CastTime + CountDownAhead
+            && RuinPvE.CanUse(out act)) return act;
+        return base.CountDownAction(remainTime);
+    }
+    #endregion
 
-			if (inBigInvocation && (elapsed0ChargeAfterInvocation || targetIsBossAndDying) && EnergySiphonPvE.CanUse(out act)) return true;
-			if (inBigInvocation && (elapsed0ChargeAfterInvocation || targetIsBossAndDying) && EnergyDrainPvE.CanUse(out act)) return true;
-			if (inBigInvocation && (elapsed1ChargeAfterInvocation || targetIsBossAndDying) && EnkindleBahamutPvE.CanUse(out act)) return true;
-			if (inBigInvocation && (elapsed1ChargeAfterInvocation || targetIsBossAndDying) && EnkindleSolarBahamutPvE.CanUse(out act)) return true;
-			if (inBigInvocation && (elapsed1ChargeAfterInvocation || targetIsBossAndDying) && EnkindlePhoenixPvE.CanUse(out act)) return true;
-			if (inBigInvocation && (elapsed1ChargeAfterInvocation || targetIsBossAndDying) && DeathflarePvE.CanUse(out act, skipAoeCheck: true)) return true;
-			if (inBigInvocation && (elapsed1ChargeAfterInvocation || targetIsBossAndDying) && SunflarePvE.CanUse(out act, skipAoeCheck: true)) return true;
-
-			if (RekindlePvE.CanUse(out act, skipAoeCheck: true)) return true;
-			if (MountainBusterPvE.CanUse(out act, skipAoeCheck: true)) return true;
-
-			if ((inSolarUnique && Player.HasStatus(false, StatusID.SearingLight) || !SearingLightPvE.EnoughLevel || isTargetBoss && isTargetDying) && EnergyDrainPvE.IsInCooldown && PainflarePvE.CanUse(out act)) return true;
-			if ((inSolarUnique && Player.HasStatus(false, StatusID.SearingLight) || !SearingLightPvE.EnoughLevel || isTargetBoss && isTargetDying) && EnergyDrainPvE.IsInCooldown && FesterPvE.CanUse(out act)) return true;
-
-			if ((elapsed2ChargeAfterInvocation || targetIsBossAndDying) && SearingFlashPvE.CanUse(out act, skipAoeCheck: true)) return true;
-			if (DoesAnyPlayerNeedHeal() && !inBigInvocation && LuxSolarisPvE.CanUse(out act)) return true;
-		}
-		else
-		{
-			bool elapsed0ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD() || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD() || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD();
-			bool elapsed1ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(1) || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(1) || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD(1);
-			bool elapsed2ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(2) || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(2) || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD(2);
-			bool elapsed3ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(3) || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(3) || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD(3);
-			bool elapsed4ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(4) || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(4) || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD(4);
-			bool elapsed6ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(6) || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(6) || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD(6);
-			bool burstInSolar = Player.Level == 100 ? InSolarBahamut : InBahamut;
-
-			if (!Player.HasStatus(false, StatusID.SearingLight) && burstInSolar && elapsed0ChargeAfterInvocation && (SearingLightPvE.Cooldown.WillHaveOneCharge(5) || !SearingLightPvE.Cooldown.IsCoolingDown))
-			{
-				UseBurstMedicine(out act);
-			}
-			
-			if (!Player.HasStatus(false, StatusID.SearingLight) && burstInSolar && elapsed1ChargeAfterInvocation)
-			{
-				if (SearingLightPvE.CanUse(out act, skipAoeCheck: true)) return true;
-			}
-
-			if (inBigInvocation && (elapsed3ChargeAfterInvocation || targetIsBossAndDying) && EnergySiphonPvE.CanUse(out act)) return true;
-			if (inBigInvocation && (elapsed3ChargeAfterInvocation || targetIsBossAndDying) && EnergyDrainPvE.CanUse(out act)) return true;
-			if (inBigInvocation && (elapsed4ChargeAfterInvocation || targetIsBossAndDying) && EnkindleBahamutPvE.CanUse(out act)) return true;
-			if (inBigInvocation && (elapsed4ChargeAfterInvocation || targetIsBossAndDying) && EnkindleSolarBahamutPvE.CanUse(out act)) return true;
-			if (inBigInvocation && (elapsed4ChargeAfterInvocation || targetIsBossAndDying) && EnkindlePhoenixPvE.CanUse(out act)) return true;
-			if (inBigInvocation && (elapsed4ChargeAfterInvocation || targetIsBossAndDying) && DeathflarePvE.CanUse(out act, skipAoeCheck: true)) return true;
-			if (inBigInvocation && (elapsed4ChargeAfterInvocation || targetIsBossAndDying) && SunflarePvE.CanUse(out act, skipAoeCheck: true)) return true;
-
-			if (RekindlePvE.CanUse(out act, skipAoeCheck: true)) return true;
-			if (MountainBusterPvE.CanUse(out act, skipAoeCheck: true)) return true;
-			
-			if ((inSolarUnique && Player.HasStatus(false, StatusID.SearingLight) && elapsed2ChargeAfterInvocation && EnergyDrainPvE.Cooldown.WillHaveOneCharge(2) || !SearingLightPvE.EnoughLevel || isTargetBoss && isTargetDying) && EnergyDrainPvE.IsInCooldown && PainflarePvE.CanUse(out act)) return true;
-			if ((inSolarUnique && Player.HasStatus(false, StatusID.SearingLight) && elapsed2ChargeAfterInvocation && EnergyDrainPvE.Cooldown.WillHaveOneCharge(2) || !SearingLightPvE.EnoughLevel || isTargetBoss && isTargetDying) && EnergyDrainPvE.IsInCooldown && FesterPvE.CanUse(out act)) return true;
-
-			if ((inSolarUnique && Player.HasStatus(false, StatusID.SearingLight) && elapsed4ChargeAfterInvocation || !SearingLightPvE.EnoughLevel || isTargetBoss && isTargetDying) && EnergyDrainPvE.IsInCooldown && PainflarePvE.CanUse(out act)) return true;
-			if ((inSolarUnique && Player.HasStatus(false, StatusID.SearingLight) && elapsed4ChargeAfterInvocation || !SearingLightPvE.EnoughLevel || isTargetBoss && isTargetDying) && EnergyDrainPvE.IsInCooldown && FesterPvE.CanUse(out act)) return true;
-			
-			if ((elapsed6ChargeAfterInvocation || targetIsBossAndDying) && SearingFlashPvE.CanUse(out act, skipAoeCheck: true)) return true;
-			if (DoesAnyPlayerNeedHeal() && !inBigInvocation && LuxSolarisPvE.CanUse(out act)) return true;
-		}
-		
-
-		return base.AttackAbility(nextGCD, out act);
-	}
-	#endregion
-
-	protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
-	{
-		bool anyBigInvocationIsCoolingDown = SummonBahamutPvE.Cooldown.IsCoolingDown || SummonSolarBahamutPvE.Cooldown.IsCoolingDown || SummonPhoenixPvE.Cooldown.IsCoolingDown;
-		if (AddSwiftcastOnGaruda && nextGCD == SlipstreamPvE && Player.Level > 86 && !InBahamut && !InPhoenix && !InSolarBahamut)
-		{ 
-			if (SwiftcastPvE.CanUse(out act)) return true;
-		}
-		
-		if ((RadiantOnCooldown && RadiantAegisPvE.Cooldown.CurrentCharges == 2 || RadiantAegisPvE.Cooldown.CurrentCharges == 1 && RadiantAegisPvE.Cooldown.WillHaveOneCharge(5)) && (anyBigInvocationIsCoolingDown && Player.Level <= 100) && RadiantAegisPvE.CanUse(out act)) return true;
-		if (RadiantOnCooldown && Player.Level < 88 && anyBigInvocationIsCoolingDown && RadiantAegisPvE.CanUse(out act)) return true;
-		
-		return base.EmergencyAbility(nextGCD, out act);
-	}
-
-	#region GCD Logic
-	protected override bool GeneralGCD(out IAction? act)
-	{
-		if (SummonCarbunclePvE.CanUse(out act)) return true;
-		
-		if (SummonBahamutPvE.CanUse(out act)) return true;
-		if ((Player.HasStatus(false, StatusID.SearingLight) || SearingLightPvE.Cooldown.IsCoolingDown) && SummonBahamutPvE.CanUse(out act)) return true;
-		if (IsBurst && (!SearingLightPvE.Cooldown.IsCoolingDown && SummonSolarBahamutPvE.CanUse(out act))) return true;
-
-		if (AddSwiftcastOnGaruda && SlipstreamPvE.CanUse(out act, skipAoeCheck: true, skipCastingCheck: !SwiftcastPvE.Cooldown.IsCoolingDown || HasSwift )) return true;
-		if (SlipstreamPvE.CanUse(out act, skipAoeCheck: true)) return true;
-
-		if (CrimsonStrikePvE.CanUse(out act, skipAoeCheck: true)) return true;
-		
-		if (PreciousBrilliancePvE.CanUse(out act)) return true;
-
-		if (GemshinePvE.CanUse(out act)) return true;
-
-		if ((!IsMoving || AddCrimsonCycloneMoving) && AddCrimsonCyclone && CrimsonCyclonePvE.CanUse(out act, skipAoeCheck: true)) return true;
-		
-		if (!SummonBahamutPvE.EnoughLevel && HasHostilesInRange && AetherchargePvE.CanUse(out act)) return true;
-		
-		if (!InBahamut && !InPhoenix && !InSolarBahamut)
-		{
-			switch (SummonOrder)
-			{
-			case SummonOrderType.TopazEmeraldRuby:
-			default:
-				if (SummonTopazPvE.CanUse(out act)) return true;
-				if (SummonEmeraldPvE.CanUse(out act)) return true;
-				if (SummonRubyPvE.CanUse(out act)) return true;
-				break;
-
-			case SummonOrderType.TopazRubyEmerald:
-				if (SummonTopazPvE.CanUse(out act)) return true;
-				if (SummonRubyPvE.CanUse(out act)) return true;
-				if (SummonEmeraldPvE.CanUse(out act)) return true;
-				break;
-
-			case SummonOrderType.EmeraldTopazRuby:
-				if (SummonEmeraldPvE.CanUse(out act)) return true;
-				if (SummonTopazPvE.CanUse(out act)) return true;
-				if (SummonRubyPvE.CanUse(out act)) return true;
-				break;
-			
-			case SummonOrderType.RubyEmeraldTopaz:
-				if (SummonRubyPvE.CanUse(out act)) return true;
-				if (SummonEmeraldPvE.CanUse(out act)) return true;
-				if (SummonTopazPvE.CanUse(out act)) return true;
-				break;
-			}
-		}
-		
-		if (SummonTimeEndAfterGCD() && AttunmentTimeEndAfterGCD() && !InBahamut && !InPhoenix && !InSolarBahamut && SummonEmeraldPvE.IsInCooldown && SummonTopazPvE.IsInCooldown && SummonRubyPvE.IsInCooldown &&
-			RuinIvPvE.CanUse(out act, skipAoeCheck: true)) return true;
-		
-		if (OutburstPvE.CanUse(out act)) return true;
-		if (RuinPvE.CanUse(out act)) return true;
-		return base.GeneralGCD(out act);
-	}
-	#endregion
-
-	#region Extra Methods
-	public override bool CanHealSingleSpell => false;
-
-	public bool DoesAnyPlayerNeedHeal()
-	{
-		return PartyMembersAverHP < 0.8f;
-	}
-	#endregion
+    #region Move Logic
+    [RotationDesc(ActionID.CrimsonCyclonePvE)]
+    protected override bool MoveForwardGCD(out IAction? act)
+    {
+        if (CrimsonCyclonePvE.CanUse(out act, skipAoeCheck: true)) return true;
+        return base.MoveForwardGCD(out act);
+    }
+    #endregion
 
 
-	// public override void DisplayStatus()
-	// {
-	// 	bool isTargetBoss = HostileTarget?.IsBossFromTTK() ?? false;
-	// 	bool isTargetDying = HostileTarget?.IsDying() ?? false;
-	// 	bool inSolarUnique = !InBahamut && !InPhoenix && InSolarBahamut;
-	//
-	// 	IAction act;
-	// 	var condition1 = $"inSolarUnique: {inSolarUnique}, Not Enough SearingLightPvE Level: {!SearingLightPvE.EnoughLevel}, isTargetBoss: {isTargetBoss}, isTargetDying: {isTargetDying}, PainflarePvE Can Use: {PainflarePvE.CanUse(out act)}";
-	// 	var condition2 = $"inSolarUnique: {inSolarUnique}, Not Enough SearingLightPvE Level: {!SearingLightPvE.EnoughLevel}, isTargetBoss: {isTargetBoss}, isTargetDying: {isTargetDying}, FesterPvE Can Use: {FesterPvE.CanUse(out act)}, NecrotizePvE Can Use: {NecrotizePvE.CanUse(out act)}";
-	//
-	// 	var conditionG = (inSolarUnique && Player.HasStatus(false, StatusID.SearingLight) || !SearingLightPvE.EnoughLevel || isTargetBoss && isTargetDying) && EnergyDrainPvE.IsInCooldown && (FesterPvE.CanUse(out act) || NecrotizePvE.CanUse(out act));
-	// 	ImGui.Text(condition1);
-	// 	ImGui.Text(condition2);
-	// 	ImGui.Text(conditionG.ToString());
-	// 	base.DisplayStatus();
-	// }
+    #region oGCD Logic
+    protected override bool AttackAbility(IAction nextGCD, out IAction? act)
+    {
+        bool isTargetBoss = HostileTarget?.IsBossFromTTK() ?? false;
+        bool isTargetDying = HostileTarget?.IsDying() ?? false;
+        bool targetIsBossAndDying = isTargetBoss && isTargetDying;
+        bool inBigInvocation = !SummonBahamutPvE.EnoughLevel || (InBahamut || InPhoenix || InSolarBahamut);
+        bool inSolarUnique = Player.Level == 100 ? !InBahamut && !InPhoenix && InSolarBahamut : InBahamut && !InPhoenix;
+        if (SecondTypeOpenerLogic)
+        {
+            bool elapsed0ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD() || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD() || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD();
+            bool elapsed1ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(1) || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(1) || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD(1);
+            bool elapsed2ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(2) || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(2) || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD(2);
+            bool burstInSolar = Player.Level == 100 ? InSolarBahamut : InBahamut;
+
+            if (!Player.HasStatus(false, StatusID.SearingLight) && burstInSolar && elapsed0ChargeAfterInvocation)
+            {
+                if (SearingLightPvE.CanUse(out act, skipAoeCheck: true)) return true;
+            }
+
+            if (inBigInvocation && (elapsed0ChargeAfterInvocation || targetIsBossAndDying) && EnergySiphonPvE.CanUse(out act)) return true;
+            if (inBigInvocation && (elapsed0ChargeAfterInvocation || targetIsBossAndDying) && EnergyDrainPvE.CanUse(out act)) return true;
+            if (inBigInvocation && (elapsed1ChargeAfterInvocation || targetIsBossAndDying) && EnkindleBahamutPvE.CanUse(out act)) return true;
+            if (inBigInvocation && (elapsed1ChargeAfterInvocation || targetIsBossAndDying) && EnkindleSolarBahamutPvE.CanUse(out act)) return true;
+            if (inBigInvocation && (elapsed1ChargeAfterInvocation || targetIsBossAndDying) && EnkindlePhoenixPvE.CanUse(out act)) return true;
+            if (inBigInvocation && (elapsed1ChargeAfterInvocation || targetIsBossAndDying) && DeathflarePvE.CanUse(out act, skipAoeCheck: true)) return true;
+            if (inBigInvocation && (elapsed1ChargeAfterInvocation || targetIsBossAndDying) && SunflarePvE.CanUse(out act, skipAoeCheck: true)) return true;
+
+            if (RekindlePvE.CanUse(out act, skipAoeCheck: true)) return true;
+            if (MountainBusterPvE.CanUse(out act, skipAoeCheck: true)) return true;
+
+            if ((inSolarUnique && Player.HasStatus(false, StatusID.SearingLight) || !SearingLightPvE.EnoughLevel || isTargetBoss && isTargetDying) && EnergyDrainPvE.IsInCooldown && PainflarePvE.CanUse(out act)) return true;
+            if ((inSolarUnique && Player.HasStatus(false, StatusID.SearingLight) || !SearingLightPvE.EnoughLevel || isTargetBoss && isTargetDying) && EnergyDrainPvE.IsInCooldown && FesterPvE.CanUse(out act)) return true;
+
+            if ((elapsed2ChargeAfterInvocation || targetIsBossAndDying) && SearingFlashPvE.CanUse(out act, skipAoeCheck: true)) return true;
+            if (DoesAnyPlayerNeedHeal() && !inBigInvocation && LuxSolarisPvE.CanUse(out act)) return true;
+        }
+        else
+        {
+            bool elapsed0ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD() || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD() || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD();
+            bool elapsed1ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(1) || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(1) || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD(1);
+            bool elapsed2ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(2) || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(2) || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD(2);
+            bool elapsed3ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(3) || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(3) || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD(3);
+            bool elapsed4ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(4) || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(4) || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD(4);
+            bool elapsed6ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(6) || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(6) || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD(6);
+            bool burstInSolar = Player.Level == 100 ? InSolarBahamut : InBahamut;
+
+            if (!Player.HasStatus(false, StatusID.SearingLight) && burstInSolar && elapsed0ChargeAfterInvocation && (SearingLightPvE.Cooldown.WillHaveOneCharge(5) || !SearingLightPvE.Cooldown.IsCoolingDown))
+            {
+                UseBurstMedicine(out act);
+            }
+
+            if (!Player.HasStatus(false, StatusID.SearingLight) && burstInSolar && elapsed1ChargeAfterInvocation)
+            {
+                if (SearingLightPvE.CanUse(out act, skipAoeCheck: true)) return true;
+            }
+
+            if (inBigInvocation && (elapsed3ChargeAfterInvocation || targetIsBossAndDying) && EnergySiphonPvE.CanUse(out act)) return true;
+            if (inBigInvocation && (elapsed3ChargeAfterInvocation || targetIsBossAndDying) && EnergyDrainPvE.CanUse(out act)) return true;
+            if (inBigInvocation && (elapsed4ChargeAfterInvocation || targetIsBossAndDying) && EnkindleBahamutPvE.CanUse(out act)) return true;
+            if (inBigInvocation && (elapsed4ChargeAfterInvocation || targetIsBossAndDying) && EnkindleSolarBahamutPvE.CanUse(out act)) return true;
+            if (inBigInvocation && (elapsed4ChargeAfterInvocation || targetIsBossAndDying) && EnkindlePhoenixPvE.CanUse(out act)) return true;
+            if (inBigInvocation && (elapsed4ChargeAfterInvocation || targetIsBossAndDying) && DeathflarePvE.CanUse(out act, skipAoeCheck: true)) return true;
+            if (inBigInvocation && (elapsed4ChargeAfterInvocation || targetIsBossAndDying) && SunflarePvE.CanUse(out act, skipAoeCheck: true)) return true;
+
+            if (RekindlePvE.CanUse(out act, skipAoeCheck: true)) return true;
+            if (MountainBusterPvE.CanUse(out act, skipAoeCheck: true)) return true;
+
+            if ((inSolarUnique && Player.HasStatus(false, StatusID.SearingLight) && elapsed2ChargeAfterInvocation && EnergyDrainPvE.Cooldown.WillHaveOneCharge(2) || !SearingLightPvE.EnoughLevel || isTargetBoss && isTargetDying) && EnergyDrainPvE.IsInCooldown && PainflarePvE.CanUse(out act)) return true;
+            if ((inSolarUnique && Player.HasStatus(false, StatusID.SearingLight) && elapsed2ChargeAfterInvocation && EnergyDrainPvE.Cooldown.WillHaveOneCharge(2) || !SearingLightPvE.EnoughLevel || isTargetBoss && isTargetDying) && EnergyDrainPvE.IsInCooldown && FesterPvE.CanUse(out act)) return true;
+
+            if ((inSolarUnique && Player.HasStatus(false, StatusID.SearingLight) && elapsed4ChargeAfterInvocation || !SearingLightPvE.EnoughLevel || isTargetBoss && isTargetDying) && EnergyDrainPvE.IsInCooldown && PainflarePvE.CanUse(out act)) return true;
+            if ((inSolarUnique && Player.HasStatus(false, StatusID.SearingLight) && elapsed4ChargeAfterInvocation || !SearingLightPvE.EnoughLevel || isTargetBoss && isTargetDying) && EnergyDrainPvE.IsInCooldown && FesterPvE.CanUse(out act)) return true;
+
+            if ((elapsed6ChargeAfterInvocation || targetIsBossAndDying) && SearingFlashPvE.CanUse(out act, skipAoeCheck: true)) return true;
+            if (DoesAnyPlayerNeedHeal() && !inBigInvocation && LuxSolarisPvE.CanUse(out act)) return true;
+        }
+
+
+        return base.AttackAbility(nextGCD, out act);
+    }
+    #endregion
+
+    protected override bool EmergencyAbility(IAction nextGCD, out IAction? act)
+    {
+        bool anyBigInvocationIsCoolingDown = SummonBahamutPvE.Cooldown.IsCoolingDown || SummonSolarBahamutPvE.Cooldown.IsCoolingDown || SummonPhoenixPvE.Cooldown.IsCoolingDown;
+        if (AddSwiftcastOnGaruda && nextGCD == SlipstreamPvE && Player.Level > 86 && !InBahamut && !InPhoenix && !InSolarBahamut)
+        {
+            if (SwiftcastPvE.CanUse(out act)) return true;
+        }
+
+        if ((RadiantOnCooldown && RadiantAegisPvE.Cooldown.CurrentCharges == 2 || RadiantAegisPvE.Cooldown.CurrentCharges == 1 && RadiantAegisPvE.Cooldown.WillHaveOneCharge(5)) && (anyBigInvocationIsCoolingDown && Player.Level <= 100) && RadiantAegisPvE.CanUse(out act)) return true;
+        if (RadiantOnCooldown && Player.Level < 88 && anyBigInvocationIsCoolingDown && RadiantAegisPvE.CanUse(out act)) return true;
+
+        return base.EmergencyAbility(nextGCD, out act);
+    }
+
+    #region GCD Logic
+    protected override bool GeneralGCD(out IAction? act)
+    {
+        if (SummonCarbunclePvE.CanUse(out act)) return true;
+
+        if (SummonBahamutPvE.CanUse(out act)) return true;
+        if ((Player.HasStatus(false, StatusID.SearingLight) || SearingLightPvE.Cooldown.IsCoolingDown) && SummonBahamutPvE.CanUse(out act)) return true;
+        if (IsBurst && (!SearingLightPvE.Cooldown.IsCoolingDown && SummonSolarBahamutPvE.CanUse(out act))) return true;
+
+        if (AddSwiftcastOnGaruda && SlipstreamPvE.CanUse(out act, skipAoeCheck: true, skipCastingCheck: !SwiftcastPvE.Cooldown.IsCoolingDown || HasSwift)) return true;
+        if (SlipstreamPvE.CanUse(out act, skipAoeCheck: true)) return true;
+
+        if (CrimsonStrikePvE.CanUse(out act, skipAoeCheck: true)) return true;
+
+        if (PreciousBrilliancePvE.CanUse(out act)) return true;
+
+        if (GemshinePvE.CanUse(out act)) return true;
+
+        if ((!IsMoving || AddCrimsonCycloneMoving) && AddCrimsonCyclone && CrimsonCyclonePvE.CanUse(out act, skipAoeCheck: true)) return true;
+
+        if (!SummonBahamutPvE.EnoughLevel && HasHostilesInRange && AetherchargePvE.CanUse(out act)) return true;
+
+        if (!InBahamut && !InPhoenix && !InSolarBahamut)
+        {
+            switch (SummonOrder)
+            {
+                case SummonOrderType.TopazEmeraldRuby:
+                default:
+                    if (SummonTopazPvE.CanUse(out act)) return true;
+                    if (SummonEmeraldPvE.CanUse(out act)) return true;
+                    if (SummonRubyPvE.CanUse(out act)) return true;
+                    break;
+
+                case SummonOrderType.TopazRubyEmerald:
+                    if (SummonTopazPvE.CanUse(out act)) return true;
+                    if (SummonRubyPvE.CanUse(out act)) return true;
+                    if (SummonEmeraldPvE.CanUse(out act)) return true;
+                    break;
+
+                case SummonOrderType.EmeraldTopazRuby:
+                    if (SummonEmeraldPvE.CanUse(out act)) return true;
+                    if (SummonTopazPvE.CanUse(out act)) return true;
+                    if (SummonRubyPvE.CanUse(out act)) return true;
+                    break;
+
+                case SummonOrderType.RubyEmeraldTopaz:
+                    if (SummonRubyPvE.CanUse(out act)) return true;
+                    if (SummonEmeraldPvE.CanUse(out act)) return true;
+                    if (SummonTopazPvE.CanUse(out act)) return true;
+                    break;
+            }
+        }
+
+        if (SummonTimeEndAfterGCD() && AttunmentTimeEndAfterGCD() && !InBahamut && !InPhoenix && !InSolarBahamut && SummonEmeraldPvE.IsInCooldown && SummonTopazPvE.IsInCooldown && SummonRubyPvE.IsInCooldown &&
+            RuinIvPvE.CanUse(out act, skipAoeCheck: true)) return true;
+
+        if (OutburstPvE.CanUse(out act)) return true;
+        if (RuinPvE.CanUse(out act)) return true;
+        return base.GeneralGCD(out act);
+    }
+    #endregion
+
+    #region Extra Methods
+    public override bool CanHealSingleSpell => false;
+
+    public bool DoesAnyPlayerNeedHeal()
+    {
+        return PartyMembersAverHP < 0.8f;
+    }
+    #endregion
+
+
+    // public override void DisplayStatus()
+    // {
+    // 	bool isTargetBoss = HostileTarget?.IsBossFromTTK() ?? false;
+    // 	bool isTargetDying = HostileTarget?.IsDying() ?? false;
+    // 	bool inSolarUnique = !InBahamut && !InPhoenix && InSolarBahamut;
+    //
+    // 	IAction act;
+    // 	var condition1 = $"inSolarUnique: {inSolarUnique}, Not Enough SearingLightPvE Level: {!SearingLightPvE.EnoughLevel}, isTargetBoss: {isTargetBoss}, isTargetDying: {isTargetDying}, PainflarePvE Can Use: {PainflarePvE.CanUse(out act)}";
+    // 	var condition2 = $"inSolarUnique: {inSolarUnique}, Not Enough SearingLightPvE Level: {!SearingLightPvE.EnoughLevel}, isTargetBoss: {isTargetBoss}, isTargetDying: {isTargetDying}, FesterPvE Can Use: {FesterPvE.CanUse(out act)}, NecrotizePvE Can Use: {NecrotizePvE.CanUse(out act)}";
+    //
+    // 	var conditionG = (inSolarUnique && Player.HasStatus(false, StatusID.SearingLight) || !SearingLightPvE.EnoughLevel || isTargetBoss && isTargetDying) && EnergyDrainPvE.IsInCooldown && (FesterPvE.CanUse(out act) || NecrotizePvE.CanUse(out act));
+    // 	ImGui.Text(condition1);
+    // 	ImGui.Text(condition2);
+    // 	ImGui.Text(conditionG.ToString());
+    // 	base.DisplayStatus();
+    // }
 
 }

--- a/BasicRotations/Melee/NIN_Default.cs
+++ b/BasicRotations/Melee/NIN_Default.cs
@@ -1,5 +1,3 @@
-using FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
-
 namespace DefaultRotations.Melee;
 
 [Rotation("Default", CombatType.PvE, GameVersion = "7.05")]

--- a/BasicRotations/Melee/VPR_Default.cs
+++ b/BasicRotations/Melee/VPR_Default.cs
@@ -147,11 +147,11 @@ public sealed class VPR_Default : ViperRotation
         }
         if (VicewinderPvE.CanUse(out act, usedUp: true)) return true;
         //AOE Serpent Combo
-        if (JaggedMawPvE.CanUse(out act)) return true;
-        if (BloodiedMawPvE.CanUse(out act)) return true;
+        if (JaggedMawPvE.CanUse(out act, skipAoeCheck: true)) return true;
+        if (BloodiedMawPvE.CanUse(out act, skipAoeCheck: true)) return true;
 
-        if (HuntersBitePvE.CanUse(out act)) return true;
-        if (SwiftskinsBitePvE.CanUse(out act)) return true;
+        if (HuntersBitePvE.CanUse(out act, skipAoeCheck: true)) return true;
+        if (SwiftskinsBitePvE.CanUse(out act, skipAoeCheck: true)) return true;
 
         if (ReavingMawPvE.CanUse(out act)) return true;
         if (SteelMawPvE.CanUse(out act)) return true;

--- a/BasicRotations/Ranged/BRD_Default.cs
+++ b/BasicRotations/Ranged/BRD_Default.cs
@@ -45,6 +45,7 @@ public sealed class BRD_Default : BardRotation
     // Defines logic for actions to take during the countdown before combat starts.
     protected override IAction? CountDownAction(float remainTime)
     {
+        // tincture needs to be used on -0.7s exactly
         if (remainTime <= 0.7f && UseBurstMedicine(out var act)) return act;
         return base.CountDownAction(remainTime);
     }
@@ -124,7 +125,7 @@ public sealed class BRD_Default : BardRotation
             }
 
             if (!NewLogicType)
-            { 
+            {
                 if (RagingStrikesPvE.CanUse(out act, isLastAbility: true))
                 {
                     if (BindWANDEnough && Song == Song.WANDERER && TheWanderersMinuetPvE.EnoughLevel) return true;
@@ -287,9 +288,9 @@ public sealed class BRD_Default : BardRotation
 
         if (HeartbreakShotPvE.CanUse(out act, usedUp: true))
         {
-            if ((!isRagingStrikesLevel) 
-                || (isRagingStrikesLevel && !isBattleVoiceLevel && Player.HasStatus(true, StatusID.RagingStrikes)) 
-                || (isBattleVoiceLevel && !isRadiantFinaleLevel && Player.HasStatus(true, StatusID.RagingStrikes) && Player.HasStatus(true, StatusID.BattleVoice)) 
+            if ((!isRagingStrikesLevel)
+                || (isRagingStrikesLevel && !isBattleVoiceLevel && Player.HasStatus(true, StatusID.RagingStrikes))
+                || (isBattleVoiceLevel && !isRadiantFinaleLevel && Player.HasStatus(true, StatusID.RagingStrikes) && Player.HasStatus(true, StatusID.BattleVoice))
                 || isRadiantFinaleLevel && Player.HasStatus(true, StatusID.RagingStrikes) && Player.HasStatus(true, StatusID.BattleVoice) && Player.HasStatus(true, StatusID.RadiantFinale)) return true;
         }
 

--- a/BasicRotations/Tank/zPLD_Alpha.cs
+++ b/BasicRotations/Tank/zPLD_Alpha.cs
@@ -10,17 +10,17 @@ public class zPLD_Alpha : PaladinRotation
 
     [RotationConfig(CombatType.PvE, Name = "Use Hallowed Ground with Cover")]
     private bool HallowedWithCover { get; set; } = true;
-    
-    [Range(1, 8,ConfigUnitType.Pixels)]
-    [RotationConfig(CombatType.PvE,Name = "How many GCDs to delay burst by (Assumes you open with Holy Spirit, 2 is best for melee opening) ")]
+
+    [Range(1, 8, ConfigUnitType.Pixels)]
+    [RotationConfig(CombatType.PvE, Name = "How many GCDs to delay burst by (Assumes you open with Holy Spirit, 2 is best for melee opening) ")]
     private int AdjustedBurst { get; set; } = 3;
-    
+
     [RotationConfig(CombatType.PvE, Name = "Prioritize Atonement Combo During Fight or Flight outside of Opener (Might not good for Dungeons Packs)")]
     private bool PrioritizeAtonementCombo { get; set; } = false;
-    
+
     [RotationConfig(CombatType.PvE, Name = "Use Holy Spirit First (For if you want to MinMax it)")]
     private bool MinMaxHolySpirit { get; set; } = false;
-    
+
     [RotationConfig(CombatType.PvE, Name = "Use Divine Veil at 15 seconds remaining on Countdown")]
     private bool UseDivineVeilPre { get; set; } = false;
 
@@ -29,13 +29,13 @@ public class zPLD_Alpha : PaladinRotation
 
     [RotationConfig(CombatType.PvE, Name = "Use Shield Bash when Low Blow is cooling down")]
     private bool UseShieldBash { get; set; } = true;
-    
-    [RotationConfig(CombatType.PvE,Name = "Allow the Use of Shield Lob")]
+
+    [RotationConfig(CombatType.PvE, Name = "Allow the Use of Shield Lob")]
     private bool UseShieldLob { get; set; } = true;
-    
+
     [RotationConfig(CombatType.PvE, Name = "Maximize Damage if Target if considered dying")]
     private bool BurstTargetIfConsideredDying { get; set; } = false;
-    
+
     [Range(0, 100, ConfigUnitType.Pixels)]
     [RotationConfig(CombatType.PvE, Name = "Use Sheltron at minimum X Oath to prevent over cap (Set to 0 to disable)")]
     private int WhenToSheltron { get; set; } = 100;
@@ -64,16 +64,16 @@ public class zPLD_Alpha : PaladinRotation
     private const ActionID ConfiteorPvEActionId = (ActionID)16459;
     private new readonly IBaseAction ConfiteorPvE = new BaseAction(ConfiteorPvEActionId);
     #endregion
-    
+
     #region Countdown Logic
     protected override IAction? CountDownAction(float remainTime)
-    {   
+    {
         if (remainTime < HolySpiritPvE.Info.CastTime + CountDownAhead
             && HolySpiritPvE.CanUse(out var act)) return act;
 
         if (remainTime < 15 && UseDivineVeilPre
             && DivineVeilPvE.CanUse(out act)) return act;
-        
+
         return base.CountDownAction(remainTime);
     }
     #endregion
@@ -136,22 +136,22 @@ public class zPLD_Alpha : PaladinRotation
         if (WeaponRemain > 0.42f)
         {
             act = null;
-            
+
             if (HasHonorReady && BladeOfHonorPvE.CanUse(out act, skipAoeCheck: true)) return true;
-            
+
             if ((InCombat && !CombatElapsedLessGCD(AdjustedBurst)))
             {
                 if (FightOrFlightPvE.CanUse(out act)) return true;
                 if (RequiescatPvE.CanUse(out act, skipAoeCheck: true, usedUp: HasFightOrFlight)) return true;
                 if (OathGauge >= WhenToSheltron && WhenToSheltron > 0 && UseOath(out act)) return true;
             }
-            
+
             if (CombatElapsedLessGCD(AdjustedBurst + 1)) return false;
-            
+
             if (FightOrFlightPvE.CanUse(out act)) return true;
             if (RequiescatPvE.CanUse(out act, skipAoeCheck: true, usedUp: HasFightOrFlight)) return true;
             if (OathGauge >= WhenToSheltron && WhenToSheltron > 0 && UseOath(out act)) return true;
-            
+
             if (CircleOfScornPvE.CanUse(out act, skipAoeCheck: true)) return true;
             if (SpiritsWithinPvE.CanUse(out act, skipAoeCheck: true)) return true;
 
@@ -163,11 +163,11 @@ public class zPLD_Alpha : PaladinRotation
     #endregion
 
     #region GCD Logic
-    protected override bool GeneralGCD(out IAction? act) 
+    protected override bool GeneralGCD(out IAction? act)
     {
         //Minimizes Accidents in EX and Savage Hopefully
-        if (IsInHighEndDuty && !InCombat){act = null; return false;}
-        
+        if (IsInHighEndDuty && !InCombat) { act = null; return false; }
+
         if (Player.HasStatus(true, StatusID.Requiescat))
         {
             if ((Player.Level >= 90) && (Player.StatusStack(true, StatusID.Requiescat) < 4))
@@ -183,7 +183,7 @@ public class zPLD_Alpha : PaladinRotation
             if (HolyCirclePvE.CanUse(out act)) return true;
             if (HolySpiritPvE.CanUse(out act)) return true;
         }
-        
+
         //AOE
         if (HasDivineMight && HolyCirclePvE.CanUse(out act)) return true;
         if (ProminencePvE.CanUse(out act)) return true;
@@ -191,44 +191,44 @@ public class zPLD_Alpha : PaladinRotation
 
         //Single
         if (UseShieldBash && ShieldBashPvE.CanUse(out act)) return true;
-        
+
         if (Player.HasStatus(true, StatusID.FightOrFlight) && AtonementCombo(out act)) return true;
         if (TargetIsDying && AtonementCombo(out act)) return true;
-        
+
         //Helps ensure Atonement combo is ready for FoF in cases of unfortunate downtime
         if (((!HasAtonementReady && (HasSepulchreReady || HasSupplicationReady || HasDivineMight)) ||
-             (HasAtonementReady && !HasDivineMight)) && 
+             (HasAtonementReady && !HasDivineMight)) &&
             !Player.HasStatus(true, StatusID.Medicated) && !RageOfHalonePvE.CanUse(out act, skipComboCheck: false))
         {
             if (RiotBladePvE.CanUse(out act) || FastBladePvE.CanUse(out act)) return true;
         }
-        
+
         if (!(HasSupplicationReady || HasSepulchreReady || HasDivineMight || HasAtonementReady) && RageOfHalonePvE.CanUse(out act)) return true;
-        
+
         if (AtonementCombo(out act)) return true;
-        
+
         if (RiotBladePvE.CanUse(out act) || FastBladePvE.CanUse(out act)) return true;
-        
+
         //Range
-         if (UseHolyWhenAway && Player.CurrentMp > 3000)
+        if (UseHolyWhenAway && Player.CurrentMp > 3000)
         {
             if (HolyCirclePvE.CanUse(out act) || HolySpiritPvE.CanUse(out act))
                 return true;
         }
-        
+
         if (UseShieldLob && ShieldLobPvE.CanUse(out act)) return true;
-        
+
         return base.GeneralGCD(out act);
     }
     #endregion
 
     #region Extra Methods
-    
+
     private bool AtonementCombo(out IAction? act) => HolySpiritFirst(out act) || GoringBladePvE.CanUse(out act) || AtonementPvE.CanUse(out act) || SupplicationPvE.CanUse(out act) || SepulchrePvE.CanUse(out act) || HasDivineMight && HolyCirclePvE.CanUse(out act) || HasDivineMight && HolySpiritPvE.CanUse(out act);
-    
+
     private bool UseOath(out IAction? act)
     {
-        act = null; 
+        act = null;
         if ((InterventionPvE.Target.Target?.GetHealthRatio() <= InterventionRatio) && InterventionPvE.CanUse(out act)) return true;
         if (SheltronPvE.CanUse(out act)) return true;
         return false;


### PR DESCRIPTION
add skips for later steps of aoe rotation to prevent bricking if enemy totals drop below AOE threshold