### PR TITLE
Refactor status checks and ability logic in VPR and BRD

### DIFF
--- a/BasicRotations/Melee/VPR_Default.cs
+++ b/BasicRotations/Melee/VPR_Default.cs
@@ -113,18 +113,18 @@ public sealed class VPR_Default : ViperRotation
         }
 
         // Uncoiled Fury Overcap protection
-        if (MaxRattling == RattlingCoilStacks || RattlingCoilStacks >= MaxUncoiledStacksUser && !Player.HasStatus(true, StatusID.Reawakened))
+        if ((MaxRattling == RattlingCoilStacks || RattlingCoilStacks >= MaxUncoiledStacksUser) && !Player.HasStatus(true, StatusID.ReadyToReawaken))
         {
             if (UncoiledFuryPvE.CanUse(out act, usedUp: true)) return true;
         }
 
-        if (BurstUncoiledFury && Player.HasStatus(true, StatusID.Medicated) && !Player.HasStatus(true, StatusID.Reawakened))
+        if (BurstUncoiledFury && Player.HasStatus(true, StatusID.Medicated) && !Player.HasStatus(true, StatusID.ReadyToReawaken))
         {
             if (UncoiledFuryPvE.CanUse(out act, usedUp: true)) return true;
         }
 
         //Uncoiled fury use
-        if (SerpentsIrePvE.Cooldown.JustUsedAfter(30) && !Player.HasStatus(true, StatusID.Reawakened))
+        if (SerpentsIrePvE.Cooldown.JustUsedAfter(30) && !Player.HasStatus(true, StatusID.ReadyToReawaken))
         {
             if (UncoiledFuryPvE.CanUse(out act, usedUp: true)) return true;
         }


### PR DESCRIPTION
Refactored status checks in `VPR_Default.cs` by replacing `StatusID.Reawakened` with `StatusID.ReadyToReawaken` in multiple conditionals, affecting abilities like `UncoiledFuryPvE` and `SerpentsIrePvE`.

Expanded `InBurstStatus` logic in `BRD_Default.cs` to include additional conditions based on player level and status effects such as `BattleVoice` and `RadiantFinale`, making the burst status check more comprehensive.

Removed BRD Experemental pot usage.

Updated logic for using `RadiantFinalePvE` and `BattleVoicePvE` in `BRD_Default.cs` to include more detailed conditions considering cooldowns and player status effects.

Modified the `GeneralGCD` method in `BRD_Default.cs` to check for the `BattleVoice` status instead of `RagingStrikes` when determining if `IronJawsPvE` should be used.