### PR TITLE
Pot usage removal

### DIFF
--- a/BasicRotations/Magical/SMN_Default.cs
+++ b/BasicRotations/Magical/SMN_Default.cs
@@ -110,11 +110,6 @@ public sealed class SMN_Default : SummonerRotation
             bool elapsed6ChargeAfterInvocation = SummonSolarBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(6) || SummonBahamutPvE.Cooldown.ElapsedOneChargeAfterGCD(6) || SummonPhoenixPvE.Cooldown.ElapsedOneChargeAfterGCD(6);
             bool burstInSolar = Player.Level == 100 ? InSolarBahamut : InBahamut;
 
-            if (!Player.HasStatus(false, StatusID.SearingLight) && burstInSolar && elapsed0ChargeAfterInvocation && (SearingLightPvE.Cooldown.WillHaveOneCharge(5) || !SearingLightPvE.Cooldown.IsCoolingDown))
-            {
-                UseBurstMedicine(out act);
-            }
-
             if (!Player.HasStatus(false, StatusID.SearingLight) && burstInSolar && elapsed1ChargeAfterInvocation)
             {
                 if (SearingLightPvE.CanUse(out act, skipAoeCheck: true)) return true;

--- a/BasicRotations/Melee/RPR_Default.cs
+++ b/BasicRotations/Melee/RPR_Default.cs
@@ -35,17 +35,6 @@ public sealed class RPR_Default : ReaperRotation
 
         if (IsBurst)
         {
-            if (UseBurstMedicine(out act))
-            {
-                if (CombatElapsedLess(10))
-                {
-                    if (!CombatElapsedLess(5)) return true;
-                }
-                else
-                {
-                    if (ArcaneCirclePvE.Cooldown.WillHaveOneCharge(5)) return true;
-                }
-            }
             if ((HostileTarget?.HasStatus(true, StatusID.DeathsDesign) ?? false)
                 && !CombatElapsedLess(3.5f) && ArcaneCirclePvE.CanUse(out act, skipAoeCheck: true)) return true;
         }

--- a/BasicRotations/Melee/VPR_Default.cs
+++ b/BasicRotations/Melee/VPR_Default.cs
@@ -29,6 +29,9 @@ public sealed class VPR_Default : ViperRotation
     [RotationConfig(CombatType.PvE, Name = "How long has to pass on Serpents Ire's cooldown before the rotation starts pooling gauge for burst. Leave this alone if you dont know what youre doing. (Will still use Reawaken if you reach cap regardless of timer)")]
     public int ReawakenDelayTimer { get; set; } = 75;
 
+    [RotationConfig(CombatType.PvE, Name = "Experimental Pot Usage(used up to 5 seconds before SerpentsIre comes off cooldown)")]
+    public bool BurstMed { get; set; } = false;
+
     #endregion
 
     private static bool IsInBurst => Player.Level > 50 && !Player.WillStatusEnd(0, true, StatusID.RagingStrikes);
@@ -49,6 +52,10 @@ public sealed class VPR_Default : ViperRotation
         if (TwinfangBitePvE.CanUse(out act)) return true;
         if (TwinbloodBitePvE.CanUse(out act)) return true;
 
+        // Use burst medicine if cooldown for Technical Step has elapsed sufficiently
+        if (BurstMed && SerpentsIrePvE.EnoughLevel && SerpentsIrePvE.Cooldown.ElapsedAfter(85)
+            && UseBurstMedicine(out act)) return true;
+
         return base.EmergencyAbility(nextGCD, out act);
     }
 
@@ -62,7 +69,7 @@ public sealed class VPR_Default : ViperRotation
     [RotationDesc]
     protected sealed override bool DefenseAreaAbility(IAction nextGCD, out IAction? act)
     {
-        if (FeintPvE.CanUse(out act)) return true;
+        if (SerpentCombo == SerpentCombo.NONE &&FeintPvE.CanUse(out act)) return true;
         return base.DefenseAreaAbility(nextGCD, out act);
     }
     #endregion

--- a/BasicRotations/Ranged/MCH_Default.cs
+++ b/BasicRotations/Ranged/MCH_Default.cs
@@ -84,8 +84,6 @@ public sealed class MCH_Default : MachinistRotation
         // Burst
         if (IsBurst)
         {
-            if (UseBurstMedicine(out act)) return true;
-
             {
                 if ((IsLastAbility(false, HyperchargePvE) || Heat >= 50 || Player.HasStatus(true, StatusID.Hypercharged)) && !CombatElapsedLessGCD(5) &&
                     (CombatElapsedLess(20) || ToolChargeSoon(out _)) && !LowLevelHyperCheck && WildfirePvE.CanUse(out act)) return true;

--- a/BasicRotations/Tank/PLD_Default.cs
+++ b/BasicRotations/Tank/PLD_Default.cs
@@ -105,7 +105,6 @@ public class PLD_Default : PaladinRotation
 
         if (InCombat)
         {
-            if (UseBurstMedicine(out act)) return true;
             if (IsBurst && !CombatElapsedLess(5) && FightOrFlightPvE.CanUse(out act)) return true;
         }
         if (CombatElapsedLess(8)) return false;

--- a/BasicRotations/Tank/WAR_Default.cs
+++ b/BasicRotations/Tank/WAR_Default.cs
@@ -78,8 +78,6 @@ public sealed class WAR_Default : WarriorRotation
 
     protected override bool GeneralAbility(IAction nextGCD, out IAction? act)
     {
-        if (IsBurstStatus && UseBurstMedicine(out act)) return true;
-
         if (Player.GetHealthRatio() < ThrillOfBattleHeal)
         {
             if (ThrillOfBattlePvE.CanUse(out act)) return true;


### PR DESCRIPTION
Removed out of countdown automatic pot usage from all but DNC, added pot usage toggle to VPR as an experiment