### PR TITLE
SGE Eurkrasia improvements, BRD buff timing fix, healer swiftcast ghosting fix #1678

### DIFF
--- a/BasicRotations/Healer/AST_Default.cs
+++ b/BasicRotations/Healer/AST_Default.cs
@@ -6,6 +6,9 @@ namespace DefaultRotations.Healer;
 public sealed class AST_Default : AstrologianRotation
 {
     #region Config Options
+    [RotationConfig(CombatType.PvE, Name = "Enable Swiftcast Restriction Logic to attempt to prevent actions other than Raise when you have swiftcast")]
+    public bool SwiftLogic { get; set; } = true;
+
     [RotationConfig(CombatType.PvE, Name = "Use spells with cast times to heal. (Ignored if you are the only healer in party)")]
     public bool GCDHeal { get; set; } = false;
 
@@ -200,6 +203,7 @@ public sealed class AST_Default : AstrologianRotation
         act = null;
         if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
         if (MicroPrio && Player.HasStatus(true, StatusID.Macrocosmos)) return false;
+        if (HasSwift && SwiftLogic) return false;
 
         if (AspectedBeneficPvE.CanUse(out act)
             && (IsMoving
@@ -217,6 +221,7 @@ public sealed class AST_Default : AstrologianRotation
         act = null;
         if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
         if (MicroPrio && Player.HasStatus(true, StatusID.Macrocosmos)) return false;
+        if (HasSwift && SwiftLogic) return false;
 
         if (AspectedHeliosPvE.CanUse(out act)) return true;
         if (HeliosPvE.CanUse(out act)) return true;
@@ -227,6 +232,7 @@ public sealed class AST_Default : AstrologianRotation
     {
         act = null;
         if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
+        if (HasSwift && SwiftLogic) return false;
 
         if (GravityPvE.CanUse(out act)) return true;
 

--- a/BasicRotations/Healer/SCH_Default.cs
+++ b/BasicRotations/Healer/SCH_Default.cs
@@ -6,6 +6,9 @@ namespace DefaultRotations.Healer;
 public sealed class SCH_Default : ScholarRotation
 {
     #region Config Options
+    [RotationConfig(CombatType.PvE, Name = "Enable Swiftcast Restriction Logic to attempt to prevent actions other than Raise when you have swiftcast")]
+    public bool SwiftLogic { get; set; } = true;
+
     [RotationConfig(CombatType.PvE, Name = "Use spells with cast times to heal. (Ignored if you are the only healer in party)")]
     public bool GCDHeal { get; set; } = false;
 
@@ -31,8 +34,10 @@ public sealed class SCH_Default : ScholarRotation
     {
         var tank = PartyMembers.GetJobCategory(JobRole.Tank);
 
+        if (SummonEosPvE.CanUse(out var act)) return act;
+
         if (remainTime < RuinPvE.Info.CastTime + CountDownAhead
-            && RuinPvE.CanUse(out var act)) return act;
+            && RuinPvE.CanUse(out act)) return act;
         if (remainTime < 3 && UseBurstMedicine(out act)) return act;
         if (remainTime is < 4 and > 3 && DeploymentTacticsPvE.CanUse(out act)) return act;
         if (remainTime is < 7 and > 6 && GiveT && AdloquiumPvE.CanUse(out act)) return act;
@@ -155,6 +160,10 @@ public sealed class SCH_Default : ScholarRotation
     [RotationDesc(ActionID.SuccorPvE)]
     protected override bool HealAreaGCD(out IAction? act)
     {
+        act = null;
+
+        if (HasSwift && SwiftLogic) return false;
+
         if (SuccorPvE.CanUse(out act)) return true;
 
         return base.HealAreaGCD(out act);
@@ -163,6 +172,10 @@ public sealed class SCH_Default : ScholarRotation
     [RotationDesc(ActionID.AdloquiumPvE, ActionID.PhysickPvE)]
     protected override bool HealSingleGCD(out IAction? act)
     {
+        act = null;
+
+        if (HasSwift && SwiftLogic) return false;
+
         if (AdloquiumPvE.CanUse(out act)) return true;
         if (PhysickPvE.CanUse(out act)) return true;
 
@@ -172,12 +185,20 @@ public sealed class SCH_Default : ScholarRotation
     [RotationDesc(ActionID.SuccorPvE)]
     protected override bool DefenseAreaGCD(out IAction? act)
     {
+        act = null;
+
+        if (HasSwift && SwiftLogic) return false;
+
         if (SuccorPvE.CanUse(out act)) return true;
         return base.DefenseAreaGCD(out act);
     }
 
     protected override bool GeneralGCD(out IAction? act)
     {
+        act = null;
+
+        if (HasSwift && SwiftLogic) return false;
+
         // Summon Eos
         if (SummonEosPvE.CanUse(out act)) return true;
 

--- a/BasicRotations/Healer/WHM_Default.cs
+++ b/BasicRotations/Healer/WHM_Default.cs
@@ -6,6 +6,8 @@ namespace DefaultRotations.Healer;
 public sealed class WHM_Default : WhiteMageRotation
 {
     #region Config Options
+    [RotationConfig(CombatType.PvE, Name = "Enable Swiftcast Restriction Logic to attempt to prevent actions other than Raise when you have swiftcast")]
+    public bool SwiftLogic { get; set; } = true;
 
     [RotationConfig(CombatType.PvE, Name = "Use spells with cast times to heal. (Ignored if you are the only healer in party)")]
     public bool GCDHeal { get; set; } = false;
@@ -144,6 +146,10 @@ public sealed class WHM_Default : WhiteMageRotation
     [RotationDesc(ActionID.AfflatusRapturePvE, ActionID.MedicaIiPvE, ActionID.CureIiiPvE, ActionID.MedicaPvE)]
     protected override bool HealAreaGCD(out IAction? act)
     {
+        act = null;
+
+        if (HasSwift && SwiftLogic) return false;
+
         if (AfflatusRapturePvE.CanUse(out act)) return true;
 
         int hasMedica2 = PartyMembers.Count((n) => n.HasStatus(true, StatusID.MedicaIi));
@@ -160,6 +166,10 @@ public sealed class WHM_Default : WhiteMageRotation
     [RotationDesc(ActionID.AfflatusSolacePvE, ActionID.RegenPvE, ActionID.CureIiPvE, ActionID.CurePvE)]
     protected override bool HealSingleGCD(out IAction? act)
     {
+        act = null;
+
+        if (HasSwift && SwiftLogic) return false;
+
         if (AfflatusSolacePvE.CanUse(out act)) return true;
 
         if (RegenPvE.CanUse(out act) && (RegenPvE.Target.Target?.GetHealthRatio() > RegenHeal)) return true;
@@ -173,6 +183,11 @@ public sealed class WHM_Default : WhiteMageRotation
 
     protected override bool GeneralGCD(out IAction? act)
     {
+
+        act = null;
+
+        if (HasSwift && SwiftLogic) return false;
+
         //if (NotInCombatDelay && RegenDefense.CanUse(out act)) return true;
 
         if (AfflatusMiseryPvE.CanUse(out act, skipAoeCheck: true)) return true;

--- a/BasicRotations/Ranged/BRD_Default.cs
+++ b/BasicRotations/Ranged/BRD_Default.cs
@@ -8,6 +8,10 @@ public sealed class BRD_Default : BardRotation
 {
     #region Config Options
 
+    [Range(1, 5, ConfigUnitType.Seconds, 0.1f)]
+    [RotationConfig(CombatType.PvE, Name = "Buff Alighnment Timer (Experimental, do not touch if you don't understand it)")]
+    public float BuffAlignment { get; set; } = 1;
+
     [Range(1, 45, ConfigUnitType.Seconds, 1)]
     [RotationConfig(CombatType.PvE, Name = "Wanderer's Minuet Uptime")]
     public float WANDTime { get; set; } = 43;
@@ -89,7 +93,7 @@ public sealed class BRD_Default : BardRotation
         if (IsBurst && Song != Song.NONE && MagesBalladPvE.EnoughLevel)
         {
             if (((!RadiantFinalePvE.EnoughLevel && !RagingStrikesPvE.Cooldown.IsCoolingDown)
-                    || (RadiantFinalePvE.EnoughLevel && !RadiantFinalePvE.Cooldown.IsCoolingDown && RagingStrikesPvE.EnoughLevel && !RagingStrikesPvE.Cooldown.IsCoolingDown))
+                    || (RadiantFinalePvE.EnoughLevel && !RadiantFinalePvE.Cooldown.IsCoolingDown && RagingStrikesPvE.EnoughLevel && (!RagingStrikesPvE.Cooldown.IsCoolingDown || RagingStrikesPvE.Cooldown.WillHaveOneCharge(BuffAlignment))))
                     && BattleVoicePvE.CanUse(out act, isLastAbility: false)) return true;
 
             if (!Player.WillStatusEnd(0, true, StatusID.BattleVoice) && RadiantFinalePvE.CanUse(out act)) return true;

--- a/BasicRotations/RebornRotations.csproj
+++ b/BasicRotations/RebornRotations.csproj
@@ -16,7 +16,7 @@
     <Compile Include="Duty\EmanationDefault" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.60" />
+    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.62" />
   </ItemGroup>
   <ItemGroup>
 	  <Reference Include="Dalamud">


### PR DESCRIPTION
Introduced SwiftLogic to healer rotations to restrict Swiftcast usage to Raise only. Modified relevant methods to check for SwiftLogic and HasSwift status. Added BuffAlignment option to Bard rotation for better buff timing control. Updated RotationSolverReborn.Basic package to version 7.0.5.62. Included missing using directive in SGE_Default.cs and improved status checks and action conditions to allow for dismissing Eurkrasia when no longer needed.