### PR TITLE
Update package version and add PrimalRendDistance config

### DIFF
--- a/BasicRotations/RebornRotations.csproj
+++ b/BasicRotations/RebornRotations.csproj
@@ -16,7 +16,7 @@
     <Compile Include="Duty\EmanationDefault" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.63" />
+    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.65" />
   </ItemGroup>
   <ItemGroup>
 	  <Reference Include="Dalamud">

--- a/BasicRotations/Tank/WAR_Default.cs
+++ b/BasicRotations/Tank/WAR_Default.cs
@@ -12,6 +12,10 @@ public sealed class WAR_Default : WarriorRotation
     [RotationConfig(CombatType.PvE, Name = "Use Bloodwhetting/Raw intuition on single enemies")]
     public bool SoloIntuition { get; set; } = false;
 
+    [Range(1, 20, ConfigUnitType.Yalms)]
+    [RotationConfig(CombatType.PvE, Name = "Max distance you can be from the boss for Primal Rend use (Danger, setting too high will get you killed)")]
+    public float PrimalRendDistance { get; set; } = 2;
+
     [Range(0, 1, ConfigUnitType.Percent)]
     [RotationConfig(CombatType.PvE, Name = "Nascent Flash Heal Threshold")]
     public float FlashHeal { get; set; } = 0.6f;
@@ -147,7 +151,7 @@ public sealed class WAR_Default : WarriorRotation
         {
             if (!IsMoving && PrimalRendPvE.CanUse(out act, skipAoeCheck: true))
             {
-                if (PrimalRendPvE.Target.Target?.DistanceToPlayer() < 2) return true;
+                if (PrimalRendPvE.Target.Target?.DistanceToPlayer() < PrimalRendDistance) return true;
             }
             if (PrimalRuinationPvE.CanUse(out act)) return true;
         }


### PR DESCRIPTION
Updated RebornRotations.csproj to change the version of the RotationSolverReborn.Basic package from 7.0.5.63 to 7.0.5.65.

Added a new configuration property PrimalRendDistance in WAR_Default.cs, allowing the maximum distance for using the Primal Rend ability to be set between 1 and 20 yalms.

Modified the logic for using the Primal Rend ability to utilize the new PrimalRendDistance property instead of a hardcoded value of 2 yalms.