### PR TITLE
Update method call and package version

### DIFF
--- a/BasicRotations/Melee/DRG_Default.cs
+++ b/BasicRotations/Melee/DRG_Default.cs
@@ -81,7 +81,7 @@ public sealed class DRG_Default : DragoonRotation
         if (JumpPvE.CanUse(out act)) return true;
         if (HighJumpPvE.CanUse(out act)) return true;
 
-        if (StardiverPvE.CanUse(out act)) return true;
+        if (StardiverPvE.CanUse(out act, isFirstAbility: true)) return true;
         if (MirageDivePvE.CanUse(out act)) return true;
         if (NastrondPvE.CanUse(out act)) return true;
         if (StarcrossPvE.CanUse(out act)) return true;

--- a/BasicRotations/RebornRotations.csproj
+++ b/BasicRotations/RebornRotations.csproj
@@ -16,7 +16,7 @@
     <Compile Include="Duty\EmanationDefault" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.74" />
+    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.78" />
   </ItemGroup>
   <ItemGroup>
 	  <Reference Include="Dalamud">


### PR DESCRIPTION
Modified `StardiverPvE.CanUse` in `DRG_Default` to include an additional `isFirstAbility` parameter set to `true`. Updated `RebornRotations.csproj` to change `RotationSolverReborn.Basic` package version from `7.0.5.74` to `7.0.5.78`.