### PR TITLE
Dancer Optimalizations

### DIFF
--- a/BasicRotations/Ranged/DNC_Default.cs
+++ b/BasicRotations/Ranged/DNC_Default.cs
@@ -56,7 +56,7 @@ public sealed class DNC_Default : DancerRotation
         if (TechnicalStepPvE.Cooldown.ElapsedAfter(115)
             && UseBurstMedicine(out act)) return true;
 
-        //If dancing or about to dance avoid using abilities to avoid animation lock delaying the GCD, except for Devilment
+        //If dancing or about to dance avoid using abilities to avoid animation lock delaying the dance, except for Devilment
         if(!IsDancing && !(StandardStepPvE.Cooldown.ElapsedAfter(28) || TechnicalStepPvE.Cooldown.ElapsedAfter(118)))
             return base.EmergencyAbility(nextGCD, out act); // Fallback to base class method if none of the above conditions are met
 
@@ -69,7 +69,7 @@ public sealed class DNC_Default : DancerRotation
     {
         act = null;
 
-        //If dancing or about to dance avoid using abilities to avoid animation lock delaying the GCD
+        //If dancing or about to dance avoid using abilities to avoid animation lock delaying the dance
         if (IsDancing || StandardStepPvE.Cooldown.ElapsedAfter(28) || TechnicalStepPvE.Cooldown.ElapsedAfter(118)) return false;
 
         // Prevent triple weaving by checking if an action was just used

--- a/BasicRotations/Ranged/DNC_Default.cs
+++ b/BasicRotations/Ranged/DNC_Default.cs
@@ -57,7 +57,7 @@ public sealed class DNC_Default : DancerRotation
             && UseBurstMedicine(out act)) return true;
 
         //If dancing or about to dance avoid using abilities to avoid animation lock delaying the GCD, except for Devilment
-        if(!IsDancing && !StandardStepPvE.Cooldown.WillHaveOneCharge(1f) && !TechnicalStepPvE.Cooldown.WillHaveOneCharge(1f))
+        if(!IsDancing && !(StandardStepPvE.Cooldown.ElapsedAfter(28) || TechnicalStepPvE.Cooldown.ElapsedAfter(118)))
             return base.EmergencyAbility(nextGCD, out act); // Fallback to base class method if none of the above conditions are met
 
         act = null;
@@ -70,7 +70,7 @@ public sealed class DNC_Default : DancerRotation
         act = null;
 
         //If dancing or about to dance avoid using abilities to avoid animation lock delaying the GCD
-        if (IsDancing || StandardStepPvE.Cooldown.WillHaveOneCharge(1f) || TechnicalStepPvE.Cooldown.WillHaveOneCharge(1f)) return false;
+        if (IsDancing || StandardStepPvE.Cooldown.ElapsedAfter(28) || TechnicalStepPvE.Cooldown.ElapsedAfter(118)) return false;
 
         // Prevent triple weaving by checking if an action was just used
         if (nextGCD.AnimationLockTime > 0.75f) return false;
@@ -211,8 +211,8 @@ public sealed class DNC_Default : DancerRotation
 
         if (StarfallDancePvE.CanUse(out act, skipAoeCheck: true)) return true;
 
-        bool standardReady = StandardStepPvE.Cooldown.WillHaveOneCharge(2.5f);
-        bool technicalReady = TechnicalStepPvE.Cooldown.WillHaveOneCharge(2.5f);
+        bool standardReady = StandardStepPvE.Cooldown.ElapsedAfter(28);
+        bool technicalReady = TechnicalStepPvE.Cooldown.ElapsedAfter(118);
 
         if (!(standardReady || technicalReady) &&
             (!shouldUseLastDance || !LastDancePvE.CanUse(out act, skipAoeCheck: true)))


### PR DESCRIPTION
Won't use abilities right before dancing or while dancing because their animation lock might delay the dance, happened to me with curing waltz.

Sometimes it used FanDance II or FanDance when FanDance III was available, now it shouldn't.
However it's hard to test since it happens rarely, but i didn't notice a single instance of it happening for 2 hours so its probably working as intented now.

The anti overcapping mechanic for feathers now uses feathers before nextGCD that can generate it, instead of instantly when it hits 4, also moved the storing feathers mechanic to when the player hits level high enough for devilment instead of tech step.

It seems that the code that prevents using standard step when it would delay tech step didn't work properly. Fixed that

Tested on Dancer Lv 72 and 60.

Also FYI my discord username is Fouramer .
Happy to contribute!