### PR TITLE
Tool Hypercharge Drifting Fix

### DIFF
--- a/BasicRotations/Ranged/MCH_Default.cs
+++ b/BasicRotations/Ranged/MCH_Default.cs
@@ -163,7 +163,7 @@ public sealed class MCH_Default : MachinistRotation
     // Logic for Hypercharge
     private bool ToolChargeSoon(out IAction? act)
     {
-        float REST_TIME = 6f;
+        float REST_TIME = 8f;
         if
                      //Cannot AOE
                      (!SpreadShotPvE.CanUse(out _)


### PR DESCRIPTION
According to the balance this should be 8-10 seconds not 6, Hypercharge takes 7.5~ seconds. Should reduce drifting chance.