### PR TITLE
Update various classes and configurations

### DIFF
--- a/BasicRotations/Healer/SGE_Default.cs
+++ b/BasicRotations/Healer/SGE_Default.cs
@@ -325,7 +325,6 @@ public sealed class SGE_Default : SageRotation
 
         if (DiagnosisPvE.CanUse(out _) && !EukrasianDiagnosisPvE.CanUse(out _, skipCastingCheck: true) && InCombat)
         {
-            StatusHelper.StatusOff(StatusID.Eukrasia);
             if (DiagnosisPvE.CanUse(out act))
             {
                 return true;
@@ -391,7 +390,7 @@ public sealed class SGE_Default : SageRotation
 
         if (DyskrasiaPvE.CanUse(out _))
         {
-            if ((EukrasianDyskrasiaPvE.Target.Target?.WillStatusEnd(3, true, EukrasianDyskrasiaPvE.Setting.TargetStatusProvide ?? []) ?? false) && InCombat)
+            if (EukrasianDyskrasiaPvE.EnoughLevel && (EukrasianDyskrasiaPvE.Target.Target?.WillStatusEnd(3, true, EukrasianDyskrasiaPvE.Setting.TargetStatusProvide ?? []) ?? false) && InCombat)
             {
                 StatusHelper.StatusOff(StatusID.Eukrasia);
             }

--- a/BasicRotations/Melee/DRG_Default.cs
+++ b/BasicRotations/Melee/DRG_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Melee;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.01")]
+[Rotation("Default", CombatType.PvE, GameVersion = "7.05")]
 [SourceCode(Path = "main/DefaultRotations/Melee/DRG_Default.cs")]
 [Api(3)]
 
@@ -9,6 +9,9 @@ public sealed class DRG_Default : DragoonRotation
     #region Config Options
     [RotationConfig(CombatType.PvE, Name = "Use Doom Spike for damage uptime if out of melee range even if it breaks combo")]
     public bool DoomSpikeWhenever { get; set; } = true;
+
+    [RotationConfig(CombatType.PvE, Name = "Attempt to assign Stardiver to the first ogcd slot (Experimental)")]
+    public bool OGCDTimers { get; set; } = false;
     #endregion
 
     private static bool InBurstStatus => !Player.WillStatusEnd(0, true, StatusID.BattleLitany);
@@ -81,7 +84,7 @@ public sealed class DRG_Default : DragoonRotation
         if (JumpPvE.CanUse(out act)) return true;
         if (HighJumpPvE.CanUse(out act)) return true;
 
-        if (StardiverPvE.CanUse(out act, isFirstAbility: true)) return true;
+        if (StardiverPvE.CanUse(out act, isFirstAbility: OGCDTimers)) return true;
         if (MirageDivePvE.CanUse(out act)) return true;
         if (NastrondPvE.CanUse(out act)) return true;
         if (StarcrossPvE.CanUse(out act)) return true;

--- a/BasicRotations/Melee/SAM_Default.cs
+++ b/BasicRotations/Melee/SAM_Default.cs
@@ -128,7 +128,7 @@ public sealed class SAM_Default : SamuraiRotation
         if ((!IsTargetBoss || (HostileTarget?.HasStatus(true, StatusID.Higanbana) ?? false)) && HasMoon && HasFlower
             && OgiNamikiriPvE.CanUse(out act)) return true;
 
-        if (((HiganbanaTargets && NumberOfAllHostilesInRange >= 2) || !HiganbanaTargets) && HiganbanaPvE.CanUse(out act)) return true;
+        if ((!HiganbanaTargets || (HiganbanaTargets && NumberOfAllHostilesInRange < 2)) && HiganbanaPvE.CanUse(out act)) return true;
 
         if (TendoSetsugekkaPvE.CanUse(out act)) return true;
         if (MidareSetsugekkaPvE.CanUse(out act)) return true;

--- a/BasicRotations/Ranged/BRD_Default.cs
+++ b/BasicRotations/Ranged/BRD_Default.cs
@@ -12,6 +12,9 @@ public sealed class BRD_Default : BardRotation
     [RotationConfig(CombatType.PvE, Name = "Buff Alighnment Timer (Experimental, do not touch if you don't understand it)")]
     public float BuffAlignment { get; set; } = 1;
 
+    [RotationConfig(CombatType.PvE, Name = "Attempt to assign Raging Strikes, Battle Voice, and Radiant Finale to specific ogcd slots (Experimental)")]
+    public bool OGCDTimers { get; set; } = false;
+
     [Range(1, 45, ConfigUnitType.Seconds, 1)]
     [RotationConfig(CombatType.PvE, Name = "Wanderer's Minuet Uptime")]
     public float WANDTime { get; set; } = 43;
@@ -94,14 +97,14 @@ public sealed class BRD_Default : BardRotation
         {
             if (((!RadiantFinalePvE.EnoughLevel && !RagingStrikesPvE.Cooldown.IsCoolingDown)
                     || (RadiantFinalePvE.EnoughLevel && !RadiantFinalePvE.Cooldown.IsCoolingDown && RagingStrikesPvE.EnoughLevel && (!RagingStrikesPvE.Cooldown.IsCoolingDown || RagingStrikesPvE.Cooldown.WillHaveOneCharge(BuffAlignment))))
-                    && (HostileTarget?.HasStatus(true, StatusID.Windbite, StatusID.Stormbite) == true) && (HostileTarget?.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite) == true) && BattleVoicePvE.CanUse(out act, isLastAbility: false)) return true;
+                    && (HostileTarget?.HasStatus(true, StatusID.Windbite, StatusID.Stormbite) == true) && (HostileTarget?.HasStatus(true, StatusID.VenomousBite, StatusID.CausticBite) == true) && BattleVoicePvE.CanUse(out act, isLastAbility: OGCDTimers)) return true;
 
-            if (!Player.WillStatusEnd(0, true, StatusID.BattleVoice) && RadiantFinalePvE.CanUse(out act)) return true;
+            if (!Player.WillStatusEnd(0, true, StatusID.BattleVoice) && RadiantFinalePvE.CanUse(out act, isFirstAbility: OGCDTimers)) return true;
 
             if (((RadiantFinalePvE.EnoughLevel && !Player.WillStatusEnd(0, true, StatusID.RadiantFinale) && !Player.WillStatusEnd(0, true, StatusID.BattleVoice))
                 || (!RadiantFinalePvE.EnoughLevel && BattleVoicePvE.EnoughLevel && !Player.WillStatusEnd(0, true, StatusID.BattleVoice))
                 || (!RadiantFinalePvE.EnoughLevel && !BattleVoicePvE.EnoughLevel))
-                && RagingStrikesPvE.CanUse(out act)) return true;
+                && RagingStrikesPvE.CanUse(out act, isLastAbility: OGCDTimers)) return true;
         }
 
         if (RadiantFinalePvE.EnoughLevel && RadiantFinalePvE.Cooldown.IsCoolingDown && BattleVoicePvE.EnoughLevel && !BattleVoicePvE.Cooldown.IsCoolingDown) return false;
@@ -119,7 +122,7 @@ public sealed class BRD_Default : BardRotation
 
             if (Repertoire == 3) return true;
 
-            if (Repertoire == 2 && EmpyrealArrowPvE.Cooldown.WillHaveOneChargeGCD()) return true;
+            if (Repertoire == 2 && EmpyrealArrowPvE.Cooldown.WillHaveOneChargeGCD() && RadiantFinalePvE.Cooldown.IsCoolingDown) return true;
         }
 
         if (MagesBalladPvE.CanUse(out act) && InCombat)
@@ -137,9 +140,9 @@ public sealed class BRD_Default : BardRotation
 
         if (SidewinderPvE.CanUse(out act))
         {
-            if (Player.HasStatus(true, StatusID.BattleVoice) && (Player.HasStatus(true, StatusID.RadiantFinale) || !RadiantFinalePvE.EnoughLevel)) return true;
+            if (Player.HasStatus(true, StatusID.BattleVoice) && (Player.HasStatus(true, StatusID.RadiantFinale) && RagingStrikesPvE.Cooldown.IsCoolingDown || !RadiantFinalePvE.EnoughLevel)) return true;
 
-            if (!BattleVoicePvE.Cooldown.WillHaveOneCharge(10) && !RadiantFinalePvE.Cooldown.WillHaveOneCharge(10)) return true;
+            if (!BattleVoicePvE.Cooldown.WillHaveOneCharge(10) && !RadiantFinalePvE.Cooldown.WillHaveOneCharge(10) && RagingStrikesPvE.Cooldown.IsCoolingDown) return true;
 
             if (RagingStrikesPvE.Cooldown.IsCoolingDown && !Player.HasStatus(true, StatusID.RagingStrikes)) return true;
         }

--- a/BasicRotations/RebornRotations.csproj
+++ b/BasicRotations/RebornRotations.csproj
@@ -16,7 +16,7 @@
     <Compile Include="Duty\EmanationDefault" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.78" />
+    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.80" />
   </ItemGroup>
   <ItemGroup>
 	  <Reference Include="Dalamud">

--- a/BasicRotations/Tank/WAR_Default.cs
+++ b/BasicRotations/Tank/WAR_Default.cs
@@ -12,6 +12,9 @@ public sealed class WAR_Default : WarriorRotation
     [RotationConfig(CombatType.PvE, Name = "Use Bloodwhetting/Raw intuition on single enemies")]
     public bool SoloIntuition { get; set; } = false;
 
+    [RotationConfig(CombatType.PvE, Name = "Use Primal Rend while moving (Danger)")]
+    public bool YEET { get; set; } = false;
+
     [Range(1, 20, ConfigUnitType.Yalms)]
     [RotationConfig(CombatType.PvE, Name = "Max distance you can be from the boss for Primal Rend use (Danger, setting too high will get you killed)")]
     public float PrimalRendDistance { get; set; } = 2;
@@ -50,7 +53,6 @@ public sealed class WAR_Default : WarriorRotation
             || !MythrilTempestPvE.EnoughLevel)
         {
             if (BerserkPvE.CanUse(out act)) return true;
-
         }
 
         if (IsBurstStatus && (InnerReleaseStacks == 0 || InnerReleaseStacks == 3))
@@ -74,7 +76,6 @@ public sealed class WAR_Default : WarriorRotation
         {
             return true;
         }
-
 
         if (MergedStatus.HasFlag(AutoStatus.MoveForward) && MoveForwardAbility(nextGCD, out act)) return true;
         return base.AttackAbility(nextGCD, out act);
@@ -149,7 +150,7 @@ public sealed class WAR_Default : WarriorRotation
 
         if (!Player.WillStatusEndGCD(3, 0, true, StatusID.SurgingTempest) && InnerReleaseStacks == 0)
         {
-            if (!IsMoving && PrimalRendPvE.CanUse(out act, skipAoeCheck: true))
+            if ((YEET || (!YEET && !IsMoving)) && PrimalRendPvE.CanUse(out act, skipAoeCheck: true))
             {
                 if (PrimalRendPvE.Target.Target?.DistanceToPlayer() < PrimalRendDistance) return true;
             }


### PR DESCRIPTION
- SGE_Default: Added level check for EukrasianDyskrasiaPvE and removed redundant status checks.
- PCT_Default: Added CountdownBuffer constant, simplified conditions, and refactored EmergencyAbility method.
- DRG_Default: Added OGCDTimers config, and modified StardiverPvE usage.
- SAM_Default: Simplified and fixed HiganbanaPvE logic.
- BRD_Default: Added OGCDTimers config and updated conditions for cooldown management.
- RebornRotations.csproj: Updated RotationSolverReborn.Basic package to 7.0.5.80.
- WAR_Default: Added YEET config for Primal Rend usage while moving and updated logic.