### PR TITLE
Update ability logic and package version

### DIFF
--- a/BasicRotations/Ranged/MCH_Default.cs
+++ b/BasicRotations/Ranged/MCH_Default.cs
@@ -125,13 +125,13 @@ public sealed class MCH_Default : MachinistRotation
         if (!SpreadShotPvE.CanUse(out _))
         {
             // use AirAnchor if possible
-            if (AirAnchorPvE.CanUse(out act)) return true;
-            // or use HotShot if low level
-            if (!AirAnchorPvE.EnoughLevel && HotShotPvE.CanUse(out act)) return true;
+            if (HotShotMasteryTrait.EnoughLevel && AirAnchorPvE.CanUse(out act)) return true;
 
             // for opener: only use the first charge of Drill after AirAnchor when there are two
             if (EnhancedMultiweaponTrait.EnoughLevel && DrillPvE.CanUse(out act, usedUp: false)) return true;
             if (!EnhancedMultiweaponTrait.EnoughLevel && DrillPvE.CanUse(out act, usedUp: true)) return true;
+
+            if (!AirAnchorPvE.EnoughLevel && HotShotPvE.CanUse(out act)) return true;
         }
 
         // ChainSaw is always used after Drill

--- a/BasicRotations/RebornRotations.csproj
+++ b/BasicRotations/RebornRotations.csproj
@@ -16,7 +16,7 @@
     <Compile Include="Duty\EmanationDefault" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.86" />
+    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.88" />
   </ItemGroup>
   <ItemGroup>
 	  <Reference Include="Dalamud">


### PR DESCRIPTION
Updated `MCH_Default.cs` to refine ability selection logic:
- Check `HotShotMasteryTrait.EnoughLevel` before using `AirAnchorPvE`.
- Moved `HotShotPvE` condition to a later point if `AirAnchorPvE` is insufficient.

Updated `RebornRotations.csproj` to use `RotationSolverReborn.Basic` version `7.0.5.88`.