### PR TITLE
Add checks to prevent redundant LightspeedPvE usage

### DIFF
--- a/BasicRotations/Healer/AST_Default.cs
+++ b/BasicRotations/Healer/AST_Default.cs
@@ -179,18 +179,24 @@ public sealed class AST_Default : AstrologianRotation
         act = null;
         if (BubbleProtec && Player.HasStatus(true, StatusID.CollectiveUnconscious_848)) return false;
 
-        if (InCombat && DivinationPvE.Cooldown.ElapsedAfter(115) && LightspeedPvE.CanUse(out act, usedUp: true)) return true;
+        if (!Player.HasStatus(true, StatusID.Lightspeed) 
+            && InCombat 
+            && DivinationPvE.Cooldown.ElapsedAfter(115) 
+            && LightspeedPvE.CanUse(out act, usedUp: true)) return true;
 
         if (IsBurst && !IsMoving
             && DivinationPvE.CanUse(out act)) return true;
 
         if (AstralDrawPvE.CanUse(out act, usedUp: IsBurst)) return true;
 
-        if ((InBurstStatus || DivinationPvE.Cooldown.ElapsedAfter(115)) && InCombat && LightspeedPvE.CanUse(out act, usedUp: true)) return true;
+        if (!Player.HasStatus(true, StatusID.Lightspeed) 
+            && (InBurstStatus || DivinationPvE.Cooldown.ElapsedAfter(115)) 
+            && InCombat 
+            && LightspeedPvE.CanUse(out act, usedUp: true)) return true;
 
         if (InCombat)
         {
-            if (IsMoving && LightspeedPvE.CanUse(out act, usedUp: LightspeedMove)) return true;
+            if (!Player.HasStatus(true, StatusID.Lightspeed) && IsMoving && LightspeedPvE.CanUse(out act, usedUp: LightspeedMove)) return true;
 
             if (!IsMoving)
             {

--- a/BasicRotations/RebornRotations.csproj
+++ b/BasicRotations/RebornRotations.csproj
@@ -16,7 +16,7 @@
     <Compile Include="Duty\EmanationDefault" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.114" />
+    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.115" />
   </ItemGroup>
   <ItemGroup>
 	  <Reference Include="Dalamud">


### PR DESCRIPTION
Enhanced the `AttackAbility` method in `AST_Default.cs` to include conditions that ensure `Lightspeed` status is not active before using `LightspeedPvE`. This prevents unnecessary usage of the `LightspeedPvE` ability when the `Lightspeed` status is already applied to the player.