### PR TITLE
Added positional feature to SAM and adjusted RPR

### DIFF
--- a/BasicRotations/Melee/RPR_Default.cs
+++ b/BasicRotations/Melee/RPR_Default.cs
@@ -148,19 +148,11 @@ public sealed class RPR_Default : ReaperRotation
             }
 
             // Try using Gallows/Gibbet that player is in position for when without Enchanced status
-            else if (CanHitPositional(EnemyPositional.Rear, GallowsPvE.Target.Target))
-            {
-                if (GallowsPvE.CanUse(out act, skipComboCheck: true)) return true;
-            }
-            else if (CanHitPositional(EnemyPositional.Flank, GibbetPvE.Target.Target))
-            {
-                if (GibbetPvE.CanUse(out act, skipComboCheck: true)) return true;
-            }
-            else
-            {
-                if (GallowsPvE.CanUse(out act, skipComboCheck: true)) return true;
-                if (GibbetPvE.CanUse(out act, skipComboCheck: true)) return true;
-            }
+            if (GallowsPvE.CanUse(out act, skipComboCheck: true) && CanHitPositional(EnemyPositional.Rear, GallowsPvE.Target.Target)) return true;
+            if (GibbetPvE.CanUse(out act, skipComboCheck: true) && CanHitPositional(EnemyPositional.Flank, GibbetPvE.Target.Target)) return true;
+
+            if (GallowsPvE.CanUse(out act, skipComboCheck: true)) return true;
+            if (GibbetPvE.CanUse(out act, skipComboCheck: true)) return true;
         }
 
         if (!CombatElapsedLessGCD(2) && PlentifulHarvestPvE.CanUse(out act, skipAoeCheck: true)) return true;
@@ -213,19 +205,11 @@ public sealed class RPR_Default : ReaperRotation
             }
 
             // Try using Executioners Gallows/Gibbet that player is in position for when without Enchanced status
-            else if (CanHitPositional(EnemyPositional.Rear, ExecutionersGallowsPvE.Target.Target))
-            {
-                if (ExecutionersGallowsPvE.CanUse(out act, skipComboCheck: true)) return true;
-            }
-            else if (CanHitPositional(EnemyPositional.Flank, ExecutionersGibbetPvE.Target.Target))
-            {
-                if (ExecutionersGibbetPvE.CanUse(out act, skipComboCheck: true)) return true;
-            }
-            else
-            {
-                if (ExecutionersGallowsPvE.CanUse(out act, skipComboCheck: true)) return true;
-                if (ExecutionersGibbetPvE.CanUse(out act, skipComboCheck: true)) return true;
-            }
+            if (ExecutionersGallowsPvE.CanUse(out act, skipComboCheck: true) && CanHitPositional(EnemyPositional.Rear, ExecutionersGallowsPvE.Target.Target)) return true;
+            if (ExecutionersGibbetPvE.CanUse(out act, skipComboCheck: true) && CanHitPositional(EnemyPositional.Flank, ExecutionersGibbetPvE.Target.Target)) return true;
+
+            if (ExecutionersGallowsPvE.CanUse(out act, skipComboCheck: true)) return true;
+            if (ExecutionersGibbetPvE.CanUse(out act, skipComboCheck: true)) return true;
         }
         act = null;
         return false;

--- a/BasicRotations/Melee/SAM_Default.cs
+++ b/BasicRotations/Melee/SAM_Default.cs
@@ -163,11 +163,17 @@ public sealed class SAM_Default : SamuraiRotation
         if (!HasSetsu && SamBuffs.All(SamBuffs => Player.HasStatus(true, SamBuffs)) && 
             YukikazePvE.CanUse(out act, skipComboCheck: HaveMeikyoShisui && HasGetsu && HasKa)) return true;
 
-        // single target 123 combo's 3 or used 3 directly during burst when MeikyoShisui is active
+        // single target 123 combo's 3 or used 3 directly during burst when MeikyoShisui is active, while also trying to start with the one that player is in position for extra DMG
+        if (GekkoPvE.CanUse(out act, skipComboCheck: HaveMeikyoShisui && !HasGetsu) && CanHitPositional(EnemyPositional.Rear, GekkoPvE.Target.Target)) return true;
+        if (KashaPvE.CanUse(out act, skipComboCheck: HaveMeikyoShisui && !HasKa) && CanHitPositional(EnemyPositional.Flank, KashaPvE.Target.Target)) return true;
+
         if (GekkoPvE.CanUse(out act, skipComboCheck: HaveMeikyoShisui && !HasGetsu)) return true;
         if (KashaPvE.CanUse(out act, skipComboCheck: HaveMeikyoShisui && !HasKa)) return true;
 
-        // single target 123 combo's 2
+        // single target 123 combo's 2, while also trying to start with the one that player is in position for extra DMG
+        if (!HasGetsu && JinpuPvE.CanUse(out act) && (CanHitPositional(EnemyPositional.Rear, JinpuPvE.Target.Target) || (!HasMoon && HasFlower))) return true;
+        if (!HasKa && ShifuPvE.CanUse(out act) && (CanHitPositional(EnemyPositional.Flank, ShifuPvE.Target.Target) || (!HasFlower && HasMoon))) return true;
+
         if ((!HasMoon || IsMoonTimeLessThanFlower || !ShifuPvE.EnoughLevel) && JinpuPvE.CanUse(out act)) return true;
         if ((!HasFlower || !IsMoonTimeLessThanFlower) && ShifuPvE.CanUse(out act)) return true;
 

--- a/BasicRotations/RebornRotations.csproj
+++ b/BasicRotations/RebornRotations.csproj
@@ -16,7 +16,7 @@
     <Compile Include="Duty\EmanationDefault" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.123" />
+    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.124" />
   </ItemGroup>
   <ItemGroup>
 	  <Reference Include="Dalamud">


### PR DESCRIPTION
- Discovered that method `CanHitPositional` is unstable when used before `CanUse`, is that because `IBaseAction.Target.Target` changes only after `CanUse`?
- Updated Package in Dependencies
- Refactored code for clarity