### PR TITLE
Update Guren for all level use

### DIFF
--- a/BasicRotations/Melee/SAM_Default.cs
+++ b/BasicRotations/Melee/SAM_Default.cs
@@ -84,7 +84,7 @@ public sealed class SAM_Default : SamuraiRotation
         }
 
         if (ZanshinPvE.CanUse(out act)) return true; // need to check rsr code for upgrade and remove aoecheck here !!! check later !!!
-        if (HissatsuGurenPvE.CanUse(out act)) return true;
+        if (HissatsuGurenPvE.CanUse(out act, skipAoeCheck: !HissatsuSeneiPvE.EnoughLevel)) return true;
         if (HissatsuSeneiPvE.CanUse(out act)) return true;
 
         if (HissatsuKyutenPvE.CanUse(out act)) return true;


### PR DESCRIPTION
Based on the recent RSR pull, update Guren so it can be used for all levels. I don't know if anyone was still using this, but I got you if you were out there.
*Who updated SAM rotation after me? Who use bana asap in opener? This is SAM default not SAM UWU... Sigh*