### PR TITLE
Update PvP classes and upgrade RotationSolverReborn

### DIFF
--- a/BasicRotations/PVPRotations/Healer/AST_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Healer/AST_Default.PVP.cs
@@ -76,11 +76,18 @@ public class AST_DefaultPVP : AstrologianRotation
         if (TryPurify(out act)) return true;
         if (UseRecuperatePvP && Player.CurrentHp / Player.MaxHp * 100 < RCValue && RecuperatePvP.CanUse(out act)) return true;
 
-        if (TheBolePvP.CanUse(out act, skipAoeCheck: true) && Player.HasStatus(true, StatusID.BoleDrawn_3403)) return true;
-        if (TheArrowPvP.CanUse(out act, skipAoeCheck: true) && Player.HasStatus(true, StatusID.ArrowDrawn_3404)) return true;
-        if (TheBalancePvP.CanUse(out act, skipAoeCheck: true) && Player.HasStatus(true, StatusID.BalanceDrawn_3101)) return true;
 
         return base.EmergencyAbility(nextGCD, out act);
+    }
+
+    protected override bool MoveForwardAbility(IAction nextGCD, out IAction? act)
+    {
+        act = null;
+
+        if (EpicyclePvP.CanUse(out act)) return true;
+
+        return base.MoveForwardAbility(nextGCD, out act);
+
     }
 
     protected override bool AttackAbility(IAction nextGCD, out IAction? act)
@@ -88,17 +95,24 @@ public class AST_DefaultPVP : AstrologianRotation
         act = null;
         if (GuardCancel && Player.HasStatus(true, StatusID.Guard)) return false;
 
+        if (OraclePvP.CanUse(out act, skipAoeCheck: true)) return true;
+
+        if (LordOfCrownsPvP.CanUse(out act, skipAoeCheck: true)) return true;
+
         if (GravityIiPvP_29248.CanUse(out act, skipAoeCheck: true)) return true;
 
         return base.AttackAbility(nextGCD, out act);
 
     }
+
     protected override bool GeneralAbility(IAction nextGCD, out IAction? act)
     {
         act = null;
         if (GuardCancel && Player.HasStatus(true, StatusID.Guard)) return false;
 
-        if (DrawPvP.CanUse(out act)) return true;
+        if (MinorArcanaPvP.CanUse(out act)) return true;
+
+        if (LadyOfCrownsPvE.CanUse(out act, skipAoeCheck: true)) return true;
 
         if (AspectedBeneficPvP_29247.CanUse(out act)) return true;
 

--- a/BasicRotations/PVPRotations/Healer/SCH_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Healer/SCH_Default.PVP.cs
@@ -87,7 +87,6 @@ public class SCH_DefaultPVP : ScholarRotation
 
         // Early exits for Guard status or Sprint usage
         if (GuardCancel && Player.HasStatus(true, StatusID.Guard)) return false;
-        if (MummificationPvP.CanUse(out act, skipAoeCheck: true)) return true;
 
         return base.AttackAbility(nextGCD, out act);
     }

--- a/BasicRotations/PVPRotations/Magical/BLM_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Magical/BLM_Default.PVP.cs
@@ -84,10 +84,6 @@ public class BLM_DefaultPVP : BlackMageRotation
         act = null;
         if (GuardCancel && Player.HasStatus(true, StatusID.Guard)) return false;
 
-        if (NightWingPvP.CanUse(out act)) return true;
-
-        if (SuperflarePvP.CanUse(out act)) return true;
-
         return base.AttackAbility(nextGCD, out act);
     }
 

--- a/BasicRotations/PVPRotations/Magical/RDM_Default.PvP.cs
+++ b/BasicRotations/PVPRotations/Magical/RDM_Default.PvP.cs
@@ -85,8 +85,8 @@ public class RDM_DefaultPvP : RedMageRotation
 
         // Early exits for Guard status or Sprint usage
         if (GuardCancel && Player.HasStatus(true, StatusID.Guard)) return false;
-        if (MagickBarrierPvP.CanUse(out act, skipAoeCheck: true)) return true;
-        if (FrazzlePvP.CanUse(out act, skipAoeCheck: true)) return true;
+        if (FortePvP.CanUse(out act)) return true;
+
         return base.DefenseAreaGCD(out act);
     }
 
@@ -97,21 +97,14 @@ public class RDM_DefaultPvP : RedMageRotation
         // Early exits for Guard status or Sprint usage
         if (GuardCancel && Player.HasStatus(true, StatusID.Guard)) return false;
 
-        if (Player.HasStatus(true, StatusID.BlackShift))
-        {
-            if (ResolutionPvP_29696.CanUse(out act)) return true;
-        }
-
-        if (Player.HasStatus(true, StatusID.WhiteShift))
-        {
-            if (ResolutionPvP.CanUse(out act)) return true;
-        }
+        if (ResolutionPvP.CanUse(out act)) return true;
 
         if (DisplacementPvP.CanUse(out act, skipAoeCheck: true)) return true;
         if (CorpsacorpsPvP.CanUse(out act, skipAoeCheck: true)) return true;
 
-        //if (BlackShiftPvP.CanUse(out act)) return true;
-        //if (WhiteShiftPvP.CanUse(out act)) return true;
+        if (PrefulgencePvP.CanUse(out act)) return true;
+        if (EmboldenPvP.CanUse(out act)) return true;
+
 
         return base.AttackAbility(nextGCD, out act);
     }
@@ -124,27 +117,12 @@ public class RDM_DefaultPvP : RedMageRotation
         if (GuardCancel && Player.HasStatus(true, StatusID.Guard)) return false;
         if (!Player.HasStatus(true, StatusID.Guard) && UseSprintPvP && !Player.HasStatus(true, StatusID.Sprint) && !InCombat && SprintPvP.CanUse(out act)) return true;
 
-        //Handling status from White Shift
-        if (Player.HasStatus(true, StatusID.WhiteShift))
-        {
-            if (VerstonePvP.CanUse(out act, skipComboCheck: true)) return true;
-            if (VeraeroIiiPvP.CanUse(out act)) return true;
-            if (EnchantedRipostePvP.CanUse(out act)) return true;
-            if (EnchantedZwerchhauPvP.CanUse(out act)) return true;
-            if (EnchantedRedoublementPvP.CanUse(out act)) return true;
-            if (VerholyPvP.CanUse(out act, skipAoeCheck: true)) return true;
-        }
-
-        //Handling status from BlackShift
-        if (Player.HasStatus(true, StatusID.BlackShift))
-        {
-            if (VerfirePvP.CanUse(out act, skipComboCheck: true)) return true;
-            if (VerthunderIiiPvP.CanUse(out act)) return true;
-            if (EnchantedRipostePvP_29692.CanUse(out act)) return true;
-            if (EnchantedZwerchhauPvP_29693.CanUse(out act)) return true;
-            if (EnchantedRedoublementPvP_29694.CanUse(out act)) return true;
-            if (VerflarePvP.CanUse(out act, skipAoeCheck: true)) return true;
-        }
+        if (JoltIiiPvP.CanUse(out act)) return true;
+        if (GrandImpactPvP.CanUse(out act)) return true;
+        if (EnchantedRipostePvP.CanUse(out act)) return true;
+        if (EnchantedZwerchhauPvP.CanUse(out act)) return true;
+        if (EnchantedRedoublementPvP.CanUse(out act)) return true;
+        if (ScorchPvP.CanUse(out act)) return true;
 
         return base.GeneralGCD(out act);
     }

--- a/BasicRotations/PVPRotations/Magical/SMN_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Magical/SMN_Default.PVP.cs
@@ -86,13 +86,7 @@ public class SMN_DefaultPvP : SummonerRotation
         act = null;
         if (GuardCancel && Player.HasStatus(true, StatusID.Guard)) return false;
 
-        if (FesterPvP.CanUse(out act)) return true;
-
         if (MountainBusterPvP.CanUse(out act)) return true;
-
-        if (EnkindleBahamutPvP.CanUse(out act)) return true;
-
-        if (EnkindlePhoenixPvP.CanUse(out act)) return true;
 
         return base.AttackAbility(nextGCD, out act);
     }

--- a/BasicRotations/PVPRotations/Melee/MNK_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Melee/MNK_Default.PVP.cs
@@ -79,19 +79,9 @@ public sealed class MNK_DefaultPvP : MonkRotation
         return base.EmergencyAbility(nextGCD, out act);
     }
 
-    protected override bool GeneralGCD(out IAction? act)
+    protected override bool AttackAbility(IAction nextGCD, out IAction? act)
     {
         act = null;
-        // Early exits for Guard status or Sprint usage
-        if (GuardCancel && Player.HasStatus(true, StatusID.Guard)) return false;
-        if (!Player.HasStatus(true, StatusID.Guard) && UseSprintPvP && !Player.HasStatus(true, StatusID.Sprint) && !InCombat && SprintPvP.CanUse(out act)) return true;
-
-        if (RisingPhoenixPvP.CanUse(out act)) return true;
-        if (EnlightenmentPvP.CanUse(out act)) return true;
-        if (RisingPhoenixPvP.CanUse(out act)) return true;
-        if (PhantomRushPvP.CanUse(out act)) return true;
-        if (SixsidedStarPvP.CanUse(out act)) return true;
-        if (EnlightenmentPvP.CanUse(out act, usedUp: true)) return true;
 
         if (InCombat)
         {
@@ -105,20 +95,33 @@ public sealed class MNK_DefaultPvP : MonkRotation
         {
             if (RiddleOfEarthPvP.CanUse(out act)) return true;
         }
+        if (EarthsReplyPvP.CanUse(out act)) return true;
+        if (WindsReplyPvP.CanUse(out act)) return true;
+        if (FiresReplyPvP.CanUse(out act)) return true;
+
+        return base.AttackAbility(nextGCD, out act);
+    }
+
+    protected override bool GeneralGCD(out IAction? act)
+    {
+        act = null;
+        // Early exits for Guard status or Sprint usage
+        if (GuardCancel && Player.HasStatus(true, StatusID.Guard)) return false;
+        if (!Player.HasStatus(true, StatusID.Guard) && UseSprintPvP && !Player.HasStatus(true, StatusID.Sprint) && !InCombat && SprintPvP.CanUse(out act)) return true;
+
+        if (FlintsReplyPvP.CanUse(out act)) return true;
 
         if (Player.HasStatus(true, StatusID.EarthResonance))
         {
             if (EarthsReplyPvP.CanUse(out act)) return true;
         }
-
         if (PhantomRushPvP.CanUse(out act)) return true;
+        if (PouncingCoeurlPvP.CanUse(out act)) return true;
+        if (RisingRaptorPvP.CanUse(out act)) return true;
+        if (LeapingOpoPvP.CanUse(out act)) return true;
         if (DemolishPvP.CanUse(out act)) return true;
         if (TwinSnakesPvP.CanUse(out act)) return true;
         if (DragonKickPvP.CanUse(out act)) return true;
-        if (SnapPunchPvP.CanUse(out act)) return true;
-        if (TrueStrikePvP.CanUse(out act)) return true;
-        if (BootshinePvP.CanUse(out act)) return true;
-
 
         return false;
     }

--- a/BasicRotations/PVPRotations/Melee/RPR_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Melee/RPR_Default.PVP.cs
@@ -112,7 +112,6 @@ public sealed class RPR_DefaultPvP : ReaperRotation
         //if (CrossReapingPvP.CanUse(out act, usedUp: true)) return true;
         //if (CommunioPvP.CanUse(out act, usedUp: true)) return true;
 
-        if (SoulSlicePvP.CanUse(out act, usedUp: true)) return true;
 
         if (PlentifulHarvestPvP.CanUse(out act)) return true;
 

--- a/BasicRotations/PVPRotations/Melee/VPR_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Melee/VPR_Default.PVP.cs
@@ -89,9 +89,11 @@ public sealed class VPR_DefaultPvP : ViperRotation
         if (ShouldCancelGuard()) return false;
 
         if (IsLastGCD((ActionID)UncoiledFuryPvP.ID) && UncoiledTwinfangPvP.CanUse(out act, skipAoeCheck: true)) return true;
-        if (IsLastGCD((ActionID)HuntersSnapPvP.ID) && TwinfangBitePvP.CanUse(out act)) return true;
-        if (IsLastGCD((ActionID)SwiftskinsCoilPvP.ID) && TwinbloodBitePvP.CanUse(out act)) return true;
-        if (IsLastGCD((ActionID)BarbarousBitePvP.ID, (ActionID)RavenousBitePvP.ID) && DeathRattlePvP.CanUse(out act)) return true;
+        if (IsLastGCD((ActionID)UncoiledFuryPvP.ID) && UncoiledTwinbloodPvP.CanUse(out act, skipAoeCheck: true)) return true;
+
+        if (BacklashPvP_39187.CanUse(out act, skipAoeCheck: true)) return true;
+
+        if (DeathRattlePvP.CanUse(out act, skipAoeCheck: true)) return true;
 
         return base.AttackAbility(nextGCD, out act);
     }
@@ -113,13 +115,11 @@ public sealed class VPR_DefaultPvP : ViperRotation
 
         if (Player.HasStatus(true, StatusID.HardenedScales)) return false;
 
-        if (!Player.HasStatus(true, StatusID.Reawakened_4094))
-        {
-            if (SwiftskinsCoilPvP.CanUse(out act, usedUp: true)) return true;
-            if (HuntersSnapPvP.CanUse(out act, usedUp: true)) return true;
-        }
 
         if (UncoiledFuryPvP.CanUse(out act, skipAoeCheck: true)) return true;
+
+        if (SanguineFeastPvP.CanUse(out act)) return true;
+        if (BloodcoilPvP.CanUse(out act)) return true;
 
         if (RavenousBitePvP.CanUse(out act)) return true;
         if (SwiftskinsStingPvP.CanUse(out act)) return true;

--- a/BasicRotations/PVPRotations/Ranged/BRD_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Ranged/BRD_Default.PVP.cs
@@ -95,7 +95,7 @@ public sealed class BRD_DefaultPvP : BardRotation
 
         if (SilentNocturnePvP.CanUse(out act)) return true;
 
-        if (EmpyrealArrowPvP.CanUse(out act)) return true;
+        if (HarmonicArrowPvP_41964.CanUse(out act)) return true;
 
         if (RepellingShotPvP.CanUse(out act)) return true;
 

--- a/BasicRotations/PVPRotations/Tank/DRK_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Tank/DRK_Default.PVP.cs
@@ -104,7 +104,6 @@ public sealed class DRK_DefaultPvP : DarkKnightRotation
         if (GuardCancel && Player.HasStatus(true, StatusID.Guard)) return false;
         if (!Player.HasStatus(true, StatusID.Guard) && UseSprintPvP && !Player.HasStatus(true, StatusID.Sprint) && !InCombat && SprintPvP.CanUse(out act)) return true;
 
-        if (QuietusPvP.CanUse(out act)) return true;
 
         if (SouleaterPvP.CanUse(out act)) return true;
         if (SyphonStrikePvP.CanUse(out act)) return true;

--- a/BasicRotations/PVPRotations/Tank/PLD_Default.PVP.cs
+++ b/BasicRotations/PVPRotations/Tank/PLD_Default.PVP.cs
@@ -86,7 +86,6 @@ public sealed class PLD_DefaultPvP : PaladinRotation
         act = null;
         if (GuardCancel && Player.HasStatus(true, StatusID.Guard)) return false;
 
-        if (ShieldBashPvP.CanUse(out act)) return true;
         if (IntervenePvP.CanUse(out act)) return true;
 
         return base.AttackAbility(nextGCD, out act);

--- a/BasicRotations/Ranged/BRD_Default.cs
+++ b/BasicRotations/Ranged/BRD_Default.cs
@@ -1,6 +1,6 @@
 namespace DefaultRotations.Ranged;
 
-[Rotation("Default", CombatType.PvE, GameVersion = "7.05",
+[Rotation("Default", CombatType.PvE, GameVersion = "7.10",
     Description = "Please make sure that the three song times add up to 120 seconds, Wanderers default first song for now.")]
 [SourceCode(Path = "main/BasicRotations/Ranged/BRD_Default.cs")]
 [Api(4)]

--- a/BasicRotations/RebornRotations.csproj
+++ b/BasicRotations/RebornRotations.csproj
@@ -16,7 +16,7 @@
     <Compile Include="Duty\EmanationDefault" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="RotationSolverReborn.Basic" Version="7.0.5.153" />
+    <PackageReference Include="RotationSolverReborn.Basic" Version="7.1.0.3" />
   </ItemGroup>
   <ItemGroup>
 	  <Reference Include="Dalamud">


### PR DESCRIPTION
Updated various PvP classes to remove outdated checks and actions, and added new abilities and checks. Key changes include:

- `AST_DefaultPVP`: Removed `TheBolePvP`, `TheArrowPvP`, `TheBalancePvP`; added `MoveForwardAbility`, `OraclePvP`, `LordOfCrownsPvP`, `MinorArcanaPvP`, `LadyOfCrownsPvE`.
- `SCH_DefaultPVP`: Removed `MummificationPvP`.
- `BLM_DefaultPVP`: Removed `NightWingPvP`, `SuperflarePvP`.
- `RDM_DefaultPvP`: Removed `MagickBarrierPvP`, `FrazzlePvP`, `WhiteShift`, `BlackShift`; added `FortePvP`, `PrefulgencePvP`, `EmboldenPvP`, `JoltIiiPvP`, `GrandImpactPvP`, `ScorchPvP`.
- `SMN_DefaultPvP`: Removed `FesterPvP`, `EnkindleBahamutPvP`, `EnkindlePhoenixPvP`.
- `MNK_DefaultPvP`: Moved `GeneralGCD` to `AttackAbility`; added `EarthsReplyPvP`, `WindsReplyPvP`, `FiresReplyPvP`, `FlintsReplyPvP`, `PouncingCoeurlPvP`, `RisingRaptorPvP`, `LeapingOpoPvP`.
- `RPR_DefaultPvP`: Removed `SoulSlicePvP`.
- `VPR_DefaultPvP`: Removed `HuntersSnapPvP`, `SwiftskinsCoilPvP`; added `UncoiledTwinbloodPvP`, `BacklashPvP_39187`, `DeathRattlePvP`, `SanguineFeastPvP`, `BloodcoilPvP`.
- `BRD_DefaultPvP`: Replaced `EmpyrealArrowPvP` with `HarmonicArrowPvP_41964`.
- `DRK_DefaultPvP`: Removed `QuietusPvP`.
- `PLD_DefaultPvP`: Removed `ShieldBashPvP`.

Upgraded `RotationSolverReborn.Basic` package from version `7.0.5.153` to `7.1.0.3` in `RebornRotations.csproj`.